### PR TITLE
Improve `move_mean` perf

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 from numbagg import move_exp_nanmean
-from numbagg.moving import move_exp_nansum, move_exp_nanvar
+from numbagg.moving import move_exp_nansum, move_exp_nanvar, move_mean
 
 
 class Suite:
@@ -35,3 +35,31 @@ class Suite:
 
     def time_pandas(self, func, n):
         func[1](self.df_ewm)
+
+
+class Moving:
+    params = [
+        [
+            (move_mean, lambda x: x.mean()),
+        ],
+        [1_000, 100_000, 10_000_000],
+    ]
+    param_names = ["func", "n"]
+    repeat = 1
+    rounds = 1
+    number = 1
+
+    def setup(self, func, n):
+        array = np.random.RandomState(0).rand(3, n)
+        self.array = np.where(array > 0.1, array, np.nan)
+        self.df_rolling = pd.DataFrame(self.array.T).rolling(window=20)
+        # One run for JIT (asv states that it does runs, but this still seems to make a
+        # difference)
+        func[0](self.array, 20)
+        func[1](self.df_rolling)
+
+    def time_numbagg(self, func, n):
+        func[0](self.array, 20)
+
+    def time_pandas(self, func, n):
+        func[1](self.df_rolling)

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -25,8 +25,8 @@ class Suite:
         array = np.random.RandomState(0).rand(3, n)
         self.array = np.where(array > 0.1, array, np.nan)
         self.df_ewm = pd.DataFrame(self.array.T).ewm(alpha=0.5)
-        # One run for JIT (asv states that it does runs, but this still seems to make a
-        # difference)
+        # One run for JIT (asv states that it does this before runs, but this still
+        # seems to make a difference)
         func[0](self.array, 0.5)
         func[1](self.df_ewm)
 
@@ -53,8 +53,8 @@ class Moving:
         array = np.random.RandomState(0).rand(3, n)
         self.array = np.where(array > 0.1, array, np.nan)
         self.df_rolling = pd.DataFrame(self.array.T).rolling(window=20)
-        # One run for JIT (asv states that it does runs, but this still seems to make a
-        # difference)
+        # One run for JIT (asv states that it does this before runs, but this still
+        # seems to make a difference)
         func[0](self.array, 20)
         func[1](self.df_rolling)
 

--- a/numbagg/moving.py
+++ b/numbagg/moving.py
@@ -107,21 +107,16 @@ def move_mean(a, window, min_count, out):
     asum = 0.0
     count = 0
 
-    for i in range(min_count - 1):
-        ai = a[i]
-        if not np.isnan(ai):
-            asum += ai
-            count += 1
-        out[i] = np.nan
+    # We previously had an initial loop which filled NaNs before `min_count`, but it
+    # didn't have a discernible effect on performance.
 
-    for i in range(min_count - 1, window):
+    for i in range(window):
         ai = a[i]
         if not np.isnan(ai):
             asum += ai
             count += 1
         out[i] = asum / count if count >= min_count else np.nan
 
-    count_inv = 1 / count if count >= min_count else np.nan
     for i in range(window, len(a)):
         ai = a[i]
         aold = a[i - window]
@@ -134,10 +129,8 @@ def move_mean(a, window, min_count, out):
         elif ai_valid:
             asum += ai
             count += 1
-            count_inv = 1 / count if count >= min_count else np.nan
         elif aold_valid:
             asum -= aold
             count -= 1
-            count_inv = 1 / count if count >= min_count else np.nan
 
-        out[i] = asum * count_inv
+        out[i] = asum / count if count >= min_count else np.nan


### PR DESCRIPTION
The attempt to avoid divides was actually costing ~20% in performance, and the initial block was not contributing. This also makes the code simpler.

This is 3-4x faster than the equivalent pandas method...
