### PR TITLE
Add `move_exp_nancov` function

### DIFF
--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -239,6 +239,8 @@ class NumbaNDMovingExp(NumbaNDMoving):
         # original array.
         # Ref https://github.com/pydata/xarray/pull/5178/files#r616168398
         if axis == ():
+            if len(arr) >= 1:
+                raise ValueError("cannot pass empty tuple for more than one arrays")
             return arr
         # For the sake of speed, we ignore divide-by-zero and NaN warnings, and test for
         # their correct handling in our tests.

--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -239,7 +239,7 @@ class NumbaNDMovingExp(NumbaNDMoving):
         # original array.
         # Ref https://github.com/pydata/xarray/pull/5178/files#r616168398
         if axis == ():
-            if len(arr) >= 1:
+            if len(arr) > 1:
                 raise ValueError("cannot pass empty tuple for more than one arrays")
             return arr
         # For the sake of speed, we ignore divide-by-zero and NaN warnings, and test for

--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -241,7 +241,7 @@ class NumbaNDMovingExp(NumbaNDMoving):
         if axis == ():
             if len(arr) > 1:
                 raise ValueError("cannot pass empty tuple for more than one arrays")
-            return arr
+            return arr[0]
         # For the sake of speed, we ignore divide-by-zero and NaN warnings, and test for
         # their correct handling in our tests.
         with np.errstate(invalid="ignore", divide="ignore"):

--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -232,7 +232,7 @@ class NumbaNDMoving:
 
 
 class NumbaNDMovingExp(NumbaNDMoving):
-    def __call__(self, arr, alpha, min_weight=0, axis=-1):
+    def __call__(self, *arr, alpha, min_weight=0, axis=-1):
         if alpha < 0:
             raise ValueError(f"alpha must be positive: {alpha}")
         # If an empty tuple is passed, there's no reduction to do, so we return the
@@ -243,7 +243,7 @@ class NumbaNDMovingExp(NumbaNDMoving):
         # For the sake of speed, we ignore divide-by-zero and NaN warnings, and test for
         # their correct handling in our tests.
         with np.errstate(invalid="ignore", divide="ignore"):
-            return self.gufunc(arr, alpha, min_weight, axis=axis)
+            return self.gufunc(*arr, alpha, min_weight, axis=axis)
 
 
 class NumbaGroupNDReduce:

--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -240,7 +240,9 @@ class NumbaNDMovingExp(NumbaNDMoving):
         # Ref https://github.com/pydata/xarray/pull/5178/files#r616168398
         if axis == ():
             if len(arr) > 1:
-                raise ValueError("cannot pass empty tuple for more than one arrays")
+                raise ValueError(
+                    "`axis` cannot be an empty tuple when passing more than one array; since we default to returning the input."
+                )
             return arr[0]
         # For the sake of speed, we ignore divide-by-zero and NaN warnings, and test for
         # their correct handling in our tests.

--- a/numbagg/moving.py
+++ b/numbagg/moving.py
@@ -127,7 +127,7 @@ def move_exp_nanvar(a, alpha, min_weight, out):
             out[i] = np.nan
 
 
-def move_exp_nanstd(a, alpha, min_weight=0):
+def move_exp_nanstd(a, *, alpha, min_weight=0):
     """
     Note that technically the unbiased weighted standard deviation is exactly the same
     as the square root of the unbiased weighted variance. But it's close, and it's what
@@ -135,7 +135,55 @@ def move_exp_nanstd(a, alpha, min_weight=0):
 
     (If anyone knows the math well and wants to take a pass at improving it, contributions are welcome.)
     """
-    return np.sqrt(move_exp_nanvar(a, alpha, min_weight))
+    return np.sqrt(move_exp_nanvar(a, alpha=alpha, min_weight=min_weight))
+
+
+@ndmovingexp(
+    # @guvectorize
+    [(float64[:], float64[:], float64, float64, float64[:])]
+)
+def move_exp_nancov(a1, a2, alpha, min_weight, out):
+    N = len(a1)
+
+    # sum_x1: decayed sum of the sequence values for a1.
+    # sum_x2: decayed sum of the sequence values for a2.
+    # sum_x1x2: decayed sum of the product of sequence values for a1 and a2.
+    # sum_weight: decayed count of non-missing values observed so far in the sequence.
+    # sum_weight2: decayed sum of the (already-decayed) weights of non-missing values.
+    sum_x1 = sum_x2 = sum_x1x2 = sum_weight = sum_weight2 = weight = 0
+    decay = 1.0 - alpha
+
+    for i in range(N):
+        a1_i = a1[i]
+        a2_i = a2[i]
+
+        # decay the values
+        sum_x1 *= decay
+        sum_x2 *= decay
+        sum_x1x2 *= decay
+        sum_weight *= decay
+        sum_weight2 *= decay**2
+        weight *= decay
+
+        if not (np.isnan(a1_i) or np.isnan(a2_i)):
+            sum_x1 += a1_i
+            sum_x2 += a2_i
+            sum_x1x2 += a1_i * a2_i
+            sum_weight += 1
+            sum_weight2 += 1
+            weight += alpha
+
+        cov_biased = (sum_x1x2 / sum_weight) - (sum_x1 / sum_weight) * (
+            sum_x2 / sum_weight
+        )
+
+        # Adjust for the bias
+        bias = 1 - sum_weight2 / (sum_weight**2)
+
+        if weight >= min_weight:
+            out[i] = cov_biased / bias
+        else:
+            out[i] = np.nan
 
 
 @ndmoving(

--- a/numbagg/moving.py
+++ b/numbagg/moving.py
@@ -179,7 +179,7 @@ def move_exp_nancov(a1, a2, alpha, min_weight, out):
             sum_x2 / sum_weight
         )
 
-        # Adjust for the bias
+        # Adjust for the bias. (explained in `move_exp_nanvar`)
         bias = 1 - sum_weight2 / (sum_weight**2)
 
         if weight >= min_weight:

--- a/numbagg/moving.py
+++ b/numbagg/moving.py
@@ -139,8 +139,10 @@ def move_exp_nanstd(a, *, alpha, min_weight=0):
 
 
 @ndmovingexp(
-    # @guvectorize
-    [(float64[:], float64[:], float64, float64, float64[:])]
+    [
+        (float32[:], float32[:], float32, float32, float32[:]),
+        (float64[:], float64[:], float64, float64, float64[:]),
+    ]
 )
 def move_exp_nancov(a1, a2, alpha, min_weight, out):
     N = len(a1)


### PR DESCRIPTION
Because we now accept multiple arrays, closing https://github.com/numbagg/numbagg/issues/61, this requires `alpha` to be kwarg-only. Which I think should be mostly fine...