### PR TITLE
Don't double-push to test-pypi on release

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -5,9 +5,6 @@ on:
   release:
     types:
       - published
-  push:
-    tags:
-      - "v*"
 
 jobs:
   build-artifacts:


### PR DESCRIPTION
Sets up a race condition that can cause the release to fail
