### PR TITLE
feat!: Set `ddof=1` as default for std & var functions

### DIFF
--- a/numbagg/funcs.py
+++ b/numbagg/funcs.py
@@ -58,8 +58,9 @@ def nanmean(a):
 
 @ndreduce([float32(float32), float64(float64)])
 def nanstd(a):
-    # for now, fix ddof=0
-    ddof = 0
+    # for now, fix ddof=1. See https://github.com/numbagg/numbagg/issues/138 for
+    # discussion of whether to add an option.
+    ddof = 1
     asum = 0
     count = 0
     for ai in a.flat:
@@ -80,8 +81,9 @@ def nanstd(a):
 
 @ndreduce([float32(float32), float64(float64)])
 def nanvar(a):
-    # for now, fix ddof=0
-    ddof = 0
+    # for now, fix ddof=1. See https://github.com/numbagg/numbagg/issues/138 for
+    # discussion of whether to add an option.
+    ddof = 1
     asum = 0
     count = 0
     for ai in a.flat:

--- a/numbagg/test/test_funcs.py
+++ b/numbagg/test/test_funcs.py
@@ -1,4 +1,5 @@
-# import bottleneck as bn
+from functools import partial
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_equal
@@ -16,8 +17,8 @@ def functions():
     yield numbagg.nanmin, np.nanmin, np.inf
     yield numbagg.nanmean, np.nanmean, 5
     yield numbagg.nanmean, np.nanmean, True
-    yield numbagg.nanstd, np.nanstd, 5
-    yield numbagg.nanvar, np.nanvar, 5
+    yield numbagg.nanstd, partial(np.nanstd, ddof=1), 5
+    yield numbagg.nanvar, partial(np.nanvar, ddof=1), 5
     # yield numbagg.anynan, bn.anynan, np.inf
     # yield numbagg.allnan, bn.allnan, np.inf
     yield numbagg.count, slow_count, np.inf

--- a/numbagg/test/test_moving.py
+++ b/numbagg/test/test_moving.py
@@ -301,12 +301,12 @@ def slow_move_mean(a, window, min_count=None, axis=-1):
     return move_func(np.nanmean, a, window, min_count, axis=axis)
 
 
-def slow_move_std(a, window, min_count=None, axis=-1, ddof=0):
+def slow_move_std(a, window, min_count=None, axis=-1, ddof=1):
     "Slow move_std for unaccelerated dtype"
     return move_func(np.nanstd, a, window, min_count, axis=axis, ddof=ddof)
 
 
-def slow_move_var(a, window, min_count=None, axis=-1, ddof=0):
+def slow_move_var(a, window, min_count=None, axis=-1, ddof=1):
     "Slow move_var for unaccelerated dtype"
     return move_func(np.nanvar, a, window, min_count, axis=axis, ddof=ddof)
 


### PR DESCRIPTION
https://github.com/numbagg/numbagg/issues/138

This was already the case for the grouped and `rolling_exp` functions.
