### PR TITLE
Add `limit` option to `ffill` & `bfill`

### DIFF
--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -198,7 +198,10 @@ class NumbaNDMoving:
     def __init__(
         self,
         func: Callable,
-        signature: tuple = ((numba.float64[:], numba.int64, numba.float64[:]),),
+        signature: list[tuple] = [
+            (numba.float64[:], numba.int64, numba.float64[:]),
+            (numba.float32[:], numba.int32, numba.float32[:]),
+        ],
         window_validator=rolling_validator,
     ):
         self.func = func
@@ -206,7 +209,9 @@ class NumbaNDMoving:
 
         for sig in signature:
             if not isinstance(sig, tuple):
-                raise TypeError(f"signatures for ndmoving must be tuples: {signature}")
+                raise TypeError(
+                    f"signatures for {self.__class__} must be tuples: {signature}"
+                )
         self.signature = signature
 
     @property
@@ -260,7 +265,7 @@ class NumbaNDFill:
     def __init__(
         self,
         func: Callable,
-        signature: tuple = [
+        signature: list[tuple] = [
             (numba.float64[:], numba.int64, numba.float64[:]),
             (numba.float32[:], numba.int32, numba.float32[:]),
         ],
@@ -269,7 +274,9 @@ class NumbaNDFill:
 
         for sig in signature:
             if not isinstance(sig, tuple):
-                raise TypeError(f"signatures for ndmoving must be tuples: {signature}")
+                raise TypeError(
+                    f"signatures for {self.__class__} must be tuples: {signature}"
+                )
         self.signature = signature
 
     @property

--- a/numbagg/funcs.py
+++ b/numbagg/funcs.py
@@ -238,8 +238,6 @@ def nanquantile(
 
 @ndfill
 def bfill(a, limit, out):
-    # if limit == -1:
-    #     limit = len(a)
     lives_remaining = limit
     current = np.nan
     # Ugly `range` expression, but can't do 'enumerate(reversed(a))', and adding a
@@ -258,8 +256,6 @@ def bfill(a, limit, out):
 
 @ndfill
 def ffill(a, limit, out):
-    # if limit == -1:
-    #     limit = len(a)
     lives_remaining = limit
     current = np.nan
     for i, val in enumerate(a):

--- a/numbagg/funcs.py
+++ b/numbagg/funcs.py
@@ -236,7 +236,7 @@ def nanquantile(
     return np.moveaxis(result, -1, 0)
 
 
-@ndfill
+@ndfill()
 def bfill(a, limit, out):
     lives_remaining = limit
     current = np.nan
@@ -254,7 +254,7 @@ def bfill(a, limit, out):
         out[i] = current
 
 
-@ndfill
+@ndfill()
 def ffill(a, limit, out):
     lives_remaining = limit
     current = np.nan

--- a/numbagg/grouped.py
+++ b/numbagg/grouped.py
@@ -1,21 +1,9 @@
 import numpy as np
-from numba import float32, float64, int32, int64
 
 from .decorators import groupndreduce
 
-dtypes = [
-    (int32, int32, int32),
-    (int32, int64, int32),
-    (int64, int32, int64),
-    (int64, int64, int64),
-    (float32, int32, float32),
-    (float32, int64, float32),
-    (float64, int32, float64),
-    (float64, int64, float64),
-]
 
-
-@groupndreduce(dtypes)
+@groupndreduce()
 def group_nanmean(values, labels, out):
     counts = np.zeros(out.shape, dtype=labels.dtype)
     out[:] = 0.0
@@ -38,7 +26,7 @@ def group_nanmean(values, labels, out):
             out[label] /= count
 
 
-@groupndreduce(dtypes)
+@groupndreduce()
 def group_nansum(values, labels, out):
     out[:] = 0
     for indices in np.ndindex(values.shape):
@@ -51,7 +39,7 @@ def group_nansum(values, labels, out):
             out[label] += value
 
 
-@groupndreduce(dtypes)
+@groupndreduce()
 def group_nancount(values, labels, out):
     out[:] = 0
     for indices in np.ndindex(values.shape):
@@ -62,7 +50,7 @@ def group_nancount(values, labels, out):
             out[label] += 1
 
 
-@groupndreduce(dtypes, supports_nd=False)
+@groupndreduce(supports_nd=False)
 def group_nanargmax(values, labels, out):
     max_values = np.full(out.shape, np.nan)
     for i in range(len(values)):
@@ -88,7 +76,7 @@ def group_nanargmax(values, labels, out):
             out[i] = np.nan
 
 
-@groupndreduce(dtypes, supports_nd=False)
+@groupndreduce(supports_nd=False)
 def group_nanargmin(values, labels, out):
     # Comments from `group_nanargmax` apply here too
     min_values = np.full(out.shape, np.nan)
@@ -107,7 +95,7 @@ def group_nanargmin(values, labels, out):
             out[idx] = np.nan
 
 
-@groupndreduce(dtypes)
+@groupndreduce()
 def group_nanfirst(values, labels, out):
     # Slightly inefficient for floats, for which we could avoid allocationg the
     # `have_seen_values` array, and instead use an array with NaNs from the start. We
@@ -125,7 +113,7 @@ def group_nanfirst(values, labels, out):
         out[~have_seen_value] = np.nan
 
 
-@groupndreduce(dtypes)
+@groupndreduce()
 def group_nanlast(values, labels, out):
     out[:] = np.nan
     for indices in np.ndindex(values.shape):
@@ -136,7 +124,7 @@ def group_nanlast(values, labels, out):
             out[label] = values[indices]
 
 
-@groupndreduce(dtypes)
+@groupndreduce()
 def group_nanprod(values, labels, out):
     out[:] = 1
     for indices in np.ndindex(values.shape):
@@ -147,7 +135,7 @@ def group_nanprod(values, labels, out):
             out[label] *= values[indices]
 
 
-@groupndreduce(dtypes)
+@groupndreduce()
 def group_nansum_of_squares(values, labels, out):
     out[:] = 0
     for indices in np.ndindex(values.shape):
@@ -158,7 +146,7 @@ def group_nansum_of_squares(values, labels, out):
             out[label] += values[indices] ** 2
 
 
-@groupndreduce(dtypes, supports_bool=False)
+@groupndreduce(supports_bool=False, supports_ints=False)
 def group_nanvar(values, labels, out):
     sums = np.zeros(out.shape, dtype=values.dtype)
     sums_of_squares = np.zeros(out.shape, dtype=values.dtype)
@@ -188,7 +176,7 @@ def group_nanvar(values, labels, out):
             )
 
 
-@groupndreduce(dtypes, supports_bool=False)
+@groupndreduce(supports_bool=False, supports_ints=False)
 def group_nanstd(values, labels, out):
     # Copy-pasted from `group_nanvar`
     sums = np.zeros(out.shape, dtype=values.dtype)
@@ -218,7 +206,7 @@ def group_nanstd(values, labels, out):
             )
 
 
-@groupndreduce(dtypes)
+@groupndreduce()
 def group_nanmin(values, labels, out):
     # Floats could save an allocation by writing directly to `out`
     min_values = np.full(out.shape, np.nan)
@@ -236,7 +224,7 @@ def group_nanmin(values, labels, out):
     out[:] = min_values
 
 
-@groupndreduce(dtypes)
+@groupndreduce()
 def group_nanmax(values, labels, out):
     # Floats could save an allocation by writing directly to `out`
     max_values = np.full(out.shape, np.nan)
@@ -254,7 +242,7 @@ def group_nanmax(values, labels, out):
     out[:] = max_values
 
 
-@groupndreduce(dtypes)
+@groupndreduce()
 def group_nanany(values, labels, out):
     out[:] = 0  # assuming 0 is 'False' for the given dtype
 
@@ -267,7 +255,7 @@ def group_nanany(values, labels, out):
             out[label] = 1
 
 
-@groupndreduce(dtypes)
+@groupndreduce()
 def group_nanall(values, labels, out):
     out[:] = 1  # assuming 1 is 'True' for the given dtype
 

--- a/numbagg/test/test_funcs.py
+++ b/numbagg/test/test_funcs.py
@@ -124,17 +124,19 @@ def test_nan_quantile():
     assert_array_almost_equal(result, expected)
 
 
-def test_ffill(rand_array):
+@pytest.mark.parametrize("limit", [1, 3, None])
+def test_ffill(rand_array, limit):
     a = rand_array[0]
-    expected = pd.Series(a).ffill().values
-    result = ffill(a)
+    expected = pd.Series(a).ffill(limit=limit).values
+    result = ffill(a, limit=limit)
 
     assert_allclose(result, expected)
 
 
-def test_bfill(rand_array):
+@pytest.mark.parametrize("limit", [1, 3, None])
+def test_bfill(rand_array, limit):
     a = rand_array[0]
-    expected = pd.Series(a).bfill().values
-    result = bfill(a)
+    expected = pd.Series(a).bfill(limit=limit).values
+    result = bfill(a, limit=limit)
 
     assert_allclose(result, expected)

--- a/numbagg/test/test_grouped.py
+++ b/numbagg/test/test_grouped.py
@@ -114,13 +114,11 @@ def test_group_pandas_comparison(values, labels, numbagg_func, pandas_func, _, d
     pandas_labels = np.where(labels >= 0, labels, np.nan)
     expected = pandas_func(pd.Series(values).groupby(pandas_labels))
     result = numbagg_func(values, labels)
-    if dtype == np.int32:
+    if dtype in [np.int32, np.int64]:
+        if not numbagg_func.supports_ints:
+            pytest.skip(f"{numbagg_func} doesn't support ints")
         if numbagg_func == group_nanprod:
             pytest.skip("group_nanprod result too large")
-        if numbagg_func == group_nanstd:
-            pytest.skip(
-                "group_nanstd returns floats for int inputs (raise issue if this is a problem)"
-            )
         assert_almost_equal(result, expected.values.astype(np.int32))
     elif dtype == np.bool_:
         if not numbagg_func.supports_bool:
@@ -213,6 +211,9 @@ def test_groupby_empty_numeric_operations(numbagg_func, pandas_func, exp):
 def test_additional_dim_equivalence(func, values, labels, dtype):
     if dtype == np.bool_ and not func.supports_bool:
         pytest.skip(f"{func} doesn't support bools")
+    if dtype in [np.int32, np.int64]:
+        if not func.supports_ints:
+            pytest.skip(f"{func} doesn't support ints")
     values = values[:10]
     labels = labels[:10]
     expected = func(values, labels)


### PR DESCRIPTION
This also does some general refactoring, and restricts a couple of functions from supplying ints — e.g. `group_nanstd`, which is a) not that useful and b) was causing some corner-case issues