### PR TITLE
`nanquantile` compatibility with `axis`

### DIFF
--- a/numbagg/test/conftest.py
+++ b/numbagg/test/conftest.py
@@ -7,6 +7,7 @@ from typing import Callable
 import bottleneck as bn
 import pandas as pd
 import pytest
+from numpy import nanquantile
 
 from .. import (
     bfill,
@@ -197,6 +198,12 @@ COMPARISONS: dict[Callable, dict[str, Callable]] = {
         bottleneck=lambda a, limit=None: lambda: bn.push(a[..., ::-1], limit)[
             ..., ::-1
         ],
+    ),
+    nanquantile: dict(
+        pandas=lambda a, quantiles=[0.25, 0.75]: lambda: pd.DataFrame(a)
+        .T.quantile(quantiles)
+        .T,
+        numbagg=lambda a, quantiles=[0.25, 0.75]: partial(nanquantile, a, quantiles),
     )
     # move_count: dict(
     #     pandas=dict(

--- a/numbagg/test/test_benchmark.py
+++ b/numbagg/test/test_benchmark.py
@@ -17,6 +17,7 @@ from .. import (
     move_std,
     move_sum,
     move_var,
+    nanquantile,
 )
 
 
@@ -37,6 +38,7 @@ from .. import (
         move_std,
         move_sum,
         move_var,
+        nanquantile,
     ],
     scope="module",
 )

--- a/numbagg/test/test_funcs.py
+++ b/numbagg/test/test_funcs.py
@@ -134,12 +134,15 @@ def slow_count(x, axis=None):
     return np.sum(~np.isnan(x), axis=axis)
 
 
-def test_nan_quantile():
+@pytest.mark.parametrize("axis", [None, -1, 1, (1, 2), (0,), (-1, -2)])
+@pytest.mark.parametrize("quantiles", [0.5, [0.25, 0.75]])
+def test_nan_quantile(axis, quantiles):
     arr = np.random.RandomState(0).rand(2000).reshape(10, 10, -1)
+    arr = np.arange(60).reshape(3, 4, 5).astype(np.float64)
 
-    quantiles = np.array([0.25, 0.75])
-    result = numbagg.nanquantile(arr, quantiles, axis=1)
-    expected = np.nanquantile(arr, quantiles, axis=1)
+    # quantiles = np.array([0.25, 0.75])
+    result = numbagg.nanquantile(arr, quantiles, axis=axis)
+    expected = np.nanquantile(arr, quantiles, axis=axis)
 
     assert_array_almost_equal(result, expected)
 


### PR DESCRIPTION
Broaden support for `nanquantile`, test across lots of axis values
