### PR TITLE
Fix nanquantile benchmarks, refactor wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ For example, here is how we wrote `nansum`:
 import numpy as np
 from numbagg.decorators import ndreduce
 
-@ndreduce()
+@ndreduce.wrap()
 def nansum(a):
     asum = 0.0
     for ai in a.flat:

--- a/numbagg/grouped.py
+++ b/numbagg/grouped.py
@@ -3,7 +3,7 @@ import numpy as np
 from .decorators import groupndreduce
 
 
-@groupndreduce()
+@groupndreduce.wrap()
 def group_nanmean(values, labels, out):
     counts = np.zeros(out.shape, dtype=labels.dtype)
     out[:] = 0.0
@@ -26,7 +26,7 @@ def group_nanmean(values, labels, out):
             out[label] /= count
 
 
-@groupndreduce()
+@groupndreduce.wrap()
 def group_nansum(values, labels, out):
     out[:] = 0
     for indices in np.ndindex(values.shape):
@@ -39,7 +39,7 @@ def group_nansum(values, labels, out):
             out[label] += value
 
 
-@groupndreduce()
+@groupndreduce.wrap()
 def group_nancount(values, labels, out):
     out[:] = 0
     for indices in np.ndindex(values.shape):
@@ -50,7 +50,7 @@ def group_nancount(values, labels, out):
             out[label] += 1
 
 
-@groupndreduce(supports_nd=False)
+@groupndreduce.wrap(supports_nd=False)
 def group_nanargmax(values, labels, out):
     max_values = np.full(out.shape, np.nan)
     for i in range(len(values)):
@@ -76,7 +76,7 @@ def group_nanargmax(values, labels, out):
             out[i] = np.nan
 
 
-@groupndreduce(supports_nd=False)
+@groupndreduce.wrap(supports_nd=False)
 def group_nanargmin(values, labels, out):
     # Comments from `group_nanargmax` apply here too
     min_values = np.full(out.shape, np.nan)
@@ -95,7 +95,7 @@ def group_nanargmin(values, labels, out):
             out[idx] = np.nan
 
 
-@groupndreduce()
+@groupndreduce.wrap()
 def group_nanfirst(values, labels, out):
     # Slightly inefficient for floats, for which we could avoid allocating the
     # `have_seen_values` array, and instead use an array with NaNs from the start. We
@@ -113,7 +113,7 @@ def group_nanfirst(values, labels, out):
         out[~have_seen_value] = np.nan
 
 
-@groupndreduce()
+@groupndreduce.wrap()
 def group_nanlast(values, labels, out):
     out[:] = np.nan
     for indices in np.ndindex(values.shape):
@@ -124,7 +124,7 @@ def group_nanlast(values, labels, out):
             out[label] = values[indices]
 
 
-@groupndreduce()
+@groupndreduce.wrap()
 def group_nanprod(values, labels, out):
     out[:] = 1
     for indices in np.ndindex(values.shape):
@@ -135,7 +135,7 @@ def group_nanprod(values, labels, out):
             out[label] *= values[indices]
 
 
-@groupndreduce()
+@groupndreduce.wrap()
 def group_nansum_of_squares(values, labels, out):
     out[:] = 0
     for indices in np.ndindex(values.shape):
@@ -146,7 +146,7 @@ def group_nansum_of_squares(values, labels, out):
             out[label] += values[indices] ** 2
 
 
-@groupndreduce(supports_bool=False, supports_ints=False)
+@groupndreduce.wrap(supports_bool=False, supports_ints=False)
 def group_nanvar(values, labels, out):
     sums = np.zeros(out.shape, dtype=values.dtype)
     sums_of_squares = np.zeros(out.shape, dtype=values.dtype)
@@ -176,7 +176,7 @@ def group_nanvar(values, labels, out):
             )
 
 
-@groupndreduce(supports_bool=False, supports_ints=False)
+@groupndreduce.wrap(supports_bool=False, supports_ints=False)
 def group_nanstd(values, labels, out):
     # Copy-pasted from `group_nanvar`
     sums = np.zeros(out.shape, dtype=values.dtype)
@@ -206,7 +206,7 @@ def group_nanstd(values, labels, out):
             )
 
 
-@groupndreduce()
+@groupndreduce.wrap()
 def group_nanmin(values, labels, out):
     # Floats could save an allocation by writing directly to `out`
     min_values = np.full(out.shape, np.nan)
@@ -224,7 +224,7 @@ def group_nanmin(values, labels, out):
     out[:] = min_values
 
 
-@groupndreduce()
+@groupndreduce.wrap()
 def group_nanmax(values, labels, out):
     # Floats could save an allocation by writing directly to `out`
     max_values = np.full(out.shape, np.nan)
@@ -242,7 +242,7 @@ def group_nanmax(values, labels, out):
     out[:] = max_values
 
 
-@groupndreduce()
+@groupndreduce.wrap()
 def group_nanany(values, labels, out):
     out[:] = 0  # assuming 0 is 'False' for the given dtype
 
@@ -255,7 +255,7 @@ def group_nanany(values, labels, out):
             out[label] = 1
 
 
-@groupndreduce()
+@groupndreduce.wrap()
 def group_nanall(values, labels, out):
     out[:] = 1  # assuming 1 is 'True' for the given dtype
 

--- a/numbagg/moving.py
+++ b/numbagg/moving.py
@@ -4,7 +4,7 @@ from numba import float32, float64, int64
 from .decorators import ndmoving
 
 
-@ndmoving(
+@ndmoving.wrap(
     [(float32[:], int64, int64, float32[:]), (float64[:], int64, int64, float64[:])]
 )
 def move_mean(a, window, min_count, out):
@@ -40,7 +40,7 @@ def move_mean(a, window, min_count, out):
         out[i] = asum / count if count >= min_count else np.nan
 
 
-@ndmoving(
+@ndmoving.wrap(
     [(float32[:], int64, int64, float32[:]), (float64[:], int64, int64, float64[:])]
 )
 def move_sum(a, window, min_count, out):
@@ -74,7 +74,7 @@ def move_sum(a, window, min_count, out):
 
 
 # TODO: pandas doesn't use a `min_count`, which maybe makes sense, but also makes it inconsistent?
-# @ndmoving(
+# @ndmoving.wrap(
 #     [(float32[:], int64, int64, float32[:]), (float64[:], int64, int64, float64[:])]
 # )
 # def move_count(a, window, min_count, out):
@@ -94,7 +94,7 @@ def move_sum(a, window, min_count, out):
 #         out[i] = count if count >= min_count else np.nan
 
 
-@ndmoving(
+@ndmoving.wrap(
     [(float32[:], int64, int64, float32[:]), (float64[:], int64, int64, float64[:])]
 )
 def move_std(a, window, min_count, out):
@@ -138,7 +138,7 @@ def move_std(a, window, min_count, out):
             out[i] = np.nan
 
 
-@ndmoving(
+@ndmoving.wrap(
     [(float32[:], int64, int64, float32[:]), (float64[:], int64, int64, float64[:])]
 )
 def move_var(a, window, min_count, out):
@@ -181,7 +181,7 @@ def move_var(a, window, min_count, out):
             out[i] = np.nan
 
 
-@ndmoving(
+@ndmoving.wrap(
     [
         (float32[:], float32[:], int64, int64, float32[:]),
         (float64[:], float64[:], int64, int64, float64[:]),
@@ -232,7 +232,7 @@ def move_cov(a, b, window, min_count, out):
             out[i] = np.nan
 
 
-@ndmoving(
+@ndmoving.wrap(
     [
         (float32[:], float32[:], int64, int64, float32[:]),
         (float64[:], float64[:], int64, int64, float64[:]),

--- a/numbagg/moving_exp.py
+++ b/numbagg/moving_exp.py
@@ -4,7 +4,7 @@ from numba import float32, float64
 from .decorators import ndmovingexp
 
 
-@ndmovingexp(
+@ndmovingexp.wrap(
     [
         (float32[:], float32, float32, float32[:]),
         (float64[:], float64, float64, float64[:]),
@@ -32,7 +32,7 @@ def move_exp_nancount(a, alpha, min_weight, out):
             out[i] = np.nan
 
 
-@ndmovingexp(
+@ndmovingexp.wrap(
     [
         (float32[:], float32, float32, float32[:]),
         (float64[:], float64, float64, float64[:]),
@@ -62,7 +62,7 @@ def move_exp_nanmean(a, alpha, min_weight, out):
             out[i] = np.nan
 
 
-@ndmovingexp(
+@ndmovingexp.wrap(
     [
         (float32[:], float32, float32, float32[:]),
         (float64[:], float64, float64, float64[:]),
@@ -92,7 +92,7 @@ def move_exp_nansum(a, alpha, min_weight, out):
             out[i] = np.nan
 
 
-@ndmovingexp(
+@ndmovingexp.wrap(
     [
         (float32[:], float32, float32, float32[:]),
         (float64[:], float64, float64, float64[:]),
@@ -144,7 +144,7 @@ def move_exp_nanvar(a, alpha, min_weight, out):
             out[i] = np.nan
 
 
-@ndmovingexp(
+@ndmovingexp.wrap(
     [
         (float32[:], float32, float32, float32[:]),
         (float64[:], float64, float64, float64[:]),
@@ -211,7 +211,7 @@ def move_exp_nanstd(a, alpha, min_weight, out):
             out[i] = np.nan
 
 
-@ndmovingexp(
+@ndmovingexp.wrap(
     [
         (float32[:], float32[:], float32, float32, float32[:]),
         (float64[:], float64[:], float64, float64, float64[:]),
@@ -259,7 +259,7 @@ def move_exp_nancov(a1, a2, alpha, min_weight, out):
             out[i] = np.nan
 
 
-@ndmovingexp(
+@ndmovingexp.wrap(
     [
         (float32[:], float32[:], float32, float32, float32[:]),
         (float64[:], float64[:], float64, float64, float64[:]),

--- a/numbagg/test/conftest.py
+++ b/numbagg/test/conftest.py
@@ -233,9 +233,9 @@ def func_callable(library, func, array):
     if len(array.shape) > 2 and library == "pandas":
         pytest.skip("pandas doesn't support array with more than 2 dimensions")
     try:
-        callable = COMPARISONS[func][library](array)
-        assert callable(Callable)
-        return callable
+        callable_ = COMPARISONS[func][library](array)
+        assert callable(callable_)
+        return callable_
     except KeyError:
         if library == "bottleneck":
             pytest.skip(f"Bottleneck doesn't support {func}")

--- a/numbagg/test/conftest.py
+++ b/numbagg/test/conftest.py
@@ -234,7 +234,7 @@ def func_callable(library, func, array):
         pytest.skip("pandas doesn't support array with more than 2 dimensions")
     try:
         callable = COMPARISONS[func][library](array)
-        assert isinstance(callable, Callable)
+        assert callable(Callable)
         return callable
     except KeyError:
         if library == "bottleneck":

--- a/numbagg/test/run_benchmarks.py
+++ b/numbagg/test/run_benchmarks.py
@@ -38,7 +38,7 @@ def run():
         )
 
     json = jq.compile(
-        '.benchmarks[] | select(.name | index("test_benchmark[")) | .params + {group, library: .params.library, func: .params.func | match("\\\\[numbagg.(.*?)\\\\]").captures[0].string, time: .stats.median, }'
+        '.benchmarks[] | select(.name | index("test_benchmark_all[")) | .params + {group, library: .params.library, func: .params.func | match("\\\\[numbagg.(.*?)\\\\]").captures[0].string, time: .stats.median, }'
     ).input(text=json_path.read_text())
 
     df = pd.DataFrame.from_dict(json.all())

--- a/numbagg/test/test_benchmark.py
+++ b/numbagg/test/test_benchmark.py
@@ -69,7 +69,7 @@ def array(shape):
     return np.where(array > 0.1, array, np.nan)
 
 
-def test_benchmark(benchmark, func, func_callable, shape):
+def test_benchmark_all(benchmark, func, func_callable, shape):
     benchmark.group = f"{func}|{shape}"
     benchmark.pedantic(
         func_callable,


### PR DESCRIPTION
This refactors the wrapper, integrating all the function — including the wrap — into the class.

I don't _love_ it — we now have this `.wrap` method which needs to be used everywhere. I really tried to make it work without that, but I don't think it's possible — we have three stages:
- The decorator receives its arguments (but not the function): previously this was an additional function, is now the `.wrap` method
- The return value of that is then called with the function: this was & is the `__init__` method of the class
- The return value of that is then the function which users can call

The main issue is that we want the class's `__call__` for the third — I had tried returning something else, like a method or a function — but then we're exporting something unusual. And the `__init__` method can't return anything, so we can't have that as the first item.

Ultimately this is all internal, and I think the proposed version is marginally better than the existing one — not much simpler, but the complexity is more encapsulated.