### PR TITLE
Benchmark compile times

### DIFF
--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, TypeVar
 
 import numba
 import numpy as np
-from numba import float64
 
 from .transform import rewrite_ndreduce
 

--- a/numbagg/funcs.py
+++ b/numbagg/funcs.py
@@ -180,7 +180,7 @@ def nanmin(a):
     return amin
 
 
-@ndquantile.wrap(signature=([(float64[:], float64[:], float64[:])], "(n),(m)->(m)"))
+@ndquantile.wrap(([(float64[:], float64[:], float64[:])], "(n),(n)->(n)"))
 def nanquantile(arr, quantile, out):
     # valid (non NaN) observations
     valid_obs = np.sum(np.isfinite(arr))

--- a/numbagg/funcs.py
+++ b/numbagg/funcs.py
@@ -180,7 +180,7 @@ def nanmin(a):
     return amin
 
 
-@ndquantile.wrap(([(float64[:], float64[:], float64[:])], "(n),(n)->(n)"))
+@ndquantile.wrap(([(float64[:], float64[:], float64[:])], "(n),(m)->(n)"))
 def nanquantile(arr, quantile, out):
     # valid (non NaN) observations
     valid_obs = np.sum(np.isfinite(arr))

--- a/numbagg/funcs.py
+++ b/numbagg/funcs.py
@@ -180,7 +180,7 @@ def nanmin(a):
     return amin
 
 
-@ndquantile.wrap(([(float64[:], float64[:], float64[:])], "(n),(m)->(n)"))
+@ndquantile.wrap(([(float64[:], float64[:], float64[:])], "(n),(m)->(m)"))
 def nanquantile(arr, quantile, out):
     # valid (non NaN) observations
     valid_obs = np.sum(np.isfinite(arr))

--- a/numbagg/test/test_benchmark.py
+++ b/numbagg/test/test_benchmark.py
@@ -51,17 +51,10 @@ def clear_numba_cache(func):
     import numbagg
 
     func.gufunc.cache_clear()
-    importlib.reload(numbagg)
 
     yield
 
 
 @pytest.mark.parametrize("shape", [(1, 20)], indirect=True)
 def test_benchmark_compile(benchmark, clear_numba_cache, func_callable):
-    def foo():
-        try:
-            func_callable()
-        except Exception:
-            pass
-
-    benchmark.pedantic(foo, warmup_rounds=0, rounds=1, iterations=1)
+    benchmark.pedantic(func_callable, warmup_rounds=0, rounds=1, iterations=1)

--- a/numbagg/test/test_benchmark.py
+++ b/numbagg/test/test_benchmark.py
@@ -1,3 +1,5 @@
+import importlib
+
 import numpy as np
 import pytest
 
@@ -42,3 +44,24 @@ def test_benchmark_f_bfill(benchmark, func_callable):
         rounds=100,
         iterations=10,
     )
+
+
+@pytest.fixture
+def clear_numba_cache(func):
+    import numbagg
+
+    func.gufunc.cache_clear()
+    importlib.reload(numbagg)
+
+    yield
+
+
+@pytest.mark.parametrize("shape", [(1, 20)], indirect=True)
+def test_benchmark_compile(benchmark, clear_numba_cache, func_callable):
+    def foo():
+        try:
+            func_callable()
+        except Exception:
+            pass
+
+    benchmark.pedantic(foo, warmup_rounds=0, rounds=1, iterations=1)

--- a/numbagg/test/test_benchmark.py
+++ b/numbagg/test/test_benchmark.py
@@ -1,5 +1,3 @@
-import importlib
-
 import numpy as np
 import pytest
 
@@ -48,8 +46,6 @@ def test_benchmark_f_bfill(benchmark, func_callable):
 
 @pytest.fixture
 def clear_numba_cache(func):
-    import numbagg
-
     func.gufunc.cache_clear()
 
     yield


### PR DESCRIPTION
One interesting observation — `nanquantile` is much much slower to compile — takes 3000ms. That seems to be because it has numpy functions in it.

https://github.com/numba/numba/issues/4807 would be really good to have, so we can cache between python runs. Atm we need to tradeoff runtime vs. start time — it's an easy call on a long-running program, which we _mostly_ have, but not always.

```

--------------------------------------------------------------------------------------------------------- benchmark: 16 tests ---------------------------------------------------------------------------------------------------------
Name (time in ms)                                                   Min                   Max                  Mean            StdDev                Median               IQR            Outliers     OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_compile[move_exp_nanmean-numbagg-shape0]        123.3281 (1.0)        123.3281 (1.0)        123.3281 (1.0)      0.0000 (1.0)        123.3281 (1.0)      0.0000 (1.0)           0;0  8.1085 (1.0)           1           1
test_benchmark_compile[move_exp_nansum-numbagg-shape0]         128.6269 (1.04)       128.6269 (1.04)       128.6269 (1.04)     0.0000 (1.0)        128.6269 (1.04)     0.0000 (1.0)           0;0  7.7744 (0.96)          1           1
test_benchmark_compile[move_exp_nanstd-numbagg-shape0]         164.1148 (1.33)       164.1148 (1.33)       164.1148 (1.33)     0.0000 (1.0)        164.1148 (1.33)     0.0000 (1.0)           0;0  6.0933 (0.75)          1           1
test_benchmark_compile[move_exp_nancount-numbagg-shape0]       177.1483 (1.44)       177.1483 (1.44)       177.1483 (1.44)     0.0000 (1.0)        177.1483 (1.44)     0.0000 (1.0)           0;0  5.6450 (0.70)          1           1
test_benchmark_compile[move_exp_nancov-numbagg-shape0]         183.3801 (1.49)       183.3801 (1.49)       183.3801 (1.49)     0.0000 (1.0)        183.3801 (1.49)     0.0000 (1.0)           0;0  5.4532 (0.67)          1           1
test_benchmark_compile[move_mean-numbagg-shape0]               193.9684 (1.57)       193.9684 (1.57)       193.9684 (1.57)     0.0000 (1.0)        193.9684 (1.57)     0.0000 (1.0)           0;0  5.1555 (0.64)          1           1
test_benchmark_compile[ffill-numbagg-shape0]                   199.6910 (1.62)       199.6910 (1.62)       199.6910 (1.62)     0.0000 (1.0)        199.6910 (1.62)     0.0000 (1.0)           0;0  5.0077 (0.62)          1           1
test_benchmark_compile[bfill-numbagg-shape0]                   202.8624 (1.64)       202.8624 (1.64)       202.8624 (1.64)     0.0000 (1.0)        202.8624 (1.64)     0.0000 (1.0)           0;0  4.9295 (0.61)          1           1
test_benchmark_compile[move_var-numbagg-shape0]                226.2350 (1.83)       226.2350 (1.83)       226.2350 (1.83)     0.0000 (1.0)        226.2350 (1.83)     0.0000 (1.0)           0;0  4.4202 (0.55)          1           1
test_benchmark_compile[move_sum-numbagg-shape0]                229.3876 (1.86)       229.3876 (1.86)       229.3876 (1.86)     0.0000 (1.0)        229.3876 (1.86)     0.0000 (1.0)           0;0  4.3594 (0.54)          1           1
test_benchmark_compile[move_std-numbagg-shape0]                233.0023 (1.89)       233.0023 (1.89)       233.0023 (1.89)     0.0000 (1.0)        233.0023 (1.89)     0.0000 (1.0)           0;0  4.2918 (0.53)          1           1
test_benchmark_compile[move_exp_nancorr-numbagg-shape0]        269.9387 (2.19)       269.9387 (2.19)       269.9387 (2.19)     0.0000 (1.0)        269.9387 (2.19)     0.0000 (1.0)           0;0  3.7045 (0.46)          1           1
test_benchmark_compile[move_cov-numbagg-shape0]                303.3732 (2.46)       303.3732 (2.46)       303.3732 (2.46)     0.0000 (1.0)        303.3732 (2.46)     0.0000 (1.0)           0;0  3.2963 (0.41)          1           1
test_benchmark_compile[move_corr-numbagg-shape0]               397.4871 (3.22)       397.4871 (3.22)       397.4871 (3.22)     0.0000 (1.0)        397.4871 (3.22)     0.0000 (1.0)           0;0  2.5158 (0.31)          1           1
test_benchmark_compile[move_exp_nanvar-numbagg-shape0]         547.1739 (4.44)       547.1739 (4.44)       547.1739 (4.44)     0.0000 (1.0)        547.1739 (4.44)     0.0000 (1.0)           0;0  1.8276 (0.23)          1           1
test_benchmark_compile[nanquantile-numbagg-shape0]           3,130.6320 (25.38)    3,130.6320 (25.38)    3,130.6320 (25.38)    0.0000 (1.0)      3,130.6320 (25.38)    0.0000 (1.0)           0;0  0.3194 (0.04)          1           1
```