### PR TITLE
Move some more benchmark configs to CLI

### DIFF
--- a/numbagg/test/run_benchmarks.py
+++ b/numbagg/test/run_benchmarks.py
@@ -36,6 +36,7 @@ def run(k_filter, run_tests):
                 f"-k={k_filter}",
                 "--benchmark-enable",
                 "--benchmark-only",
+                "--benchmark-max-time=5",
                 "--run-nightly",
                 f"--benchmark-json={json_path}",
             ],

--- a/numbagg/test/test_benchmark.py
+++ b/numbagg/test/test_benchmark.py
@@ -22,12 +22,8 @@ def shape(request):
     "library", ["numbagg", "pandas", "bottleneck", "numpy"], indirect=True
 )
 @pytest.mark.benchmark(
-    # Can increase this if we're comparing code changes
-    max_time=2,
     warmup=True,
     warmup_iterations=1,
-    # We care more about accuracy than deviations, so we set this high
-    calibration_precision=10,
 )
 def test_benchmark_main(benchmark, func, func_callable, shape):
     """


### PR DESCRIPTION
This lets us pass `--benchmark-max-time=0.1` or `=10` for varying precision
