### PR TITLE
More accurate benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,46 +47,46 @@ items.
 
 | func                      | pandas<br>`(10000000,)` | bottleneck<br>`(10000000,)` | numpy<br>`(10000000,)` | pandas<br>`(100, 100000)` | bottleneck<br>`(100, 100000)` | numpy<br>`(100, 100000)` |
 | :------------------------ | ----------------------: | --------------------------: | ---------------------: | ------------------------: | ----------------------------: | -----------------------: |
-| `bfill`                   |                   1.16x |                       1.18x |                    n/a |                    11.31x |                         4.05x |                      n/a |
-| `ffill`                   |                   1.21x |                       1.18x |                    n/a |                    12.60x |                         4.39x |                      n/a |
-| `group_nanall`            |                   1.41x |                         n/a |                    n/a |                    10.70x |                           n/a |                      n/a |
-| `group_nanany`            |                   1.16x |                         n/a |                    n/a |                     5.49x |                           n/a |                      n/a |
-| `group_nanargmax`         |                   2.83x |                         n/a |                    n/a |                    11.44x |                           n/a |                      n/a |
-| `group_nanargmin`         |                   2.85x |                         n/a |                    n/a |                    11.18x |                           n/a |                      n/a |
-| `group_nancount`          |                   1.01x |                         n/a |                    n/a |                     4.62x |                           n/a |                      n/a |
-| `group_nanfirst`          |                   1.38x |                         n/a |                    n/a |                    11.76x |                           n/a |                      n/a |
-| `group_nanlast`           |                   1.12x |                         n/a |                    n/a |                     4.66x |                           n/a |                      n/a |
-| `group_nanmax`            |                   1.12x |                         n/a |                    n/a |                     4.54x |                           n/a |                      n/a |
-| `group_nanmean`           |                   1.16x |                         n/a |                    n/a |                     5.28x |                           n/a |                      n/a |
-| `group_nanmin`            |                   1.13x |                         n/a |                    n/a |                     4.52x |                           n/a |                      n/a |
-| `group_nanprod`           |                   1.09x |                         n/a |                    n/a |                     4.93x |                           n/a |                      n/a |
-| `group_nanstd`            |                   1.21x |                         n/a |                    n/a |                     4.82x |                           n/a |                      n/a |
-| `group_nansum_of_squares` |                   1.36x |                         n/a |                    n/a |                     2.62x |                           n/a |                      n/a |
-| `group_nansum`            |                   1.22x |                         n/a |                    n/a |                     5.18x |                           n/a |                      n/a |
-| `group_nanvar`            |                   1.19x |                         n/a |                    n/a |                     4.86x |                           n/a |                      n/a |
-| `move_corr`               |                  19.56x |                         n/a |                    n/a |                    82.74x |                           n/a |                      n/a |
-| `move_cov`                |                  14.46x |                         n/a |                    n/a |                    68.84x |                           n/a |                      n/a |
-| `move_exp_nancorr`        |                   6.99x |                         n/a |                    n/a |                    30.75x |                           n/a |                      n/a |
-| `move_exp_nancount`       |                   2.36x |                         n/a |                    n/a |                    10.49x |                           n/a |                      n/a |
-| `move_exp_nancov`         |                   6.12x |                         n/a |                    n/a |                    30.65x |                           n/a |                      n/a |
-| `move_exp_nanmean`        |                   2.17x |                         n/a |                    n/a |                    10.67x |                           n/a |                      n/a |
-| `move_exp_nanstd`         |                   1.87x |                         n/a |                    n/a |                     9.98x |                           n/a |                      n/a |
-| `move_exp_nansum`         |                   1.90x |                         n/a |                    n/a |                     8.17x |                           n/a |                      n/a |
-| `move_exp_nanvar`         |                   1.81x |                         n/a |                    n/a |                     8.84x |                           n/a |                      n/a |
-| `move_mean`               |                   3.85x |                       0.88x |                    n/a |                    17.69x |                         4.16x |                      n/a |
-| `move_std`                |                   5.96x |                       1.32x |                    n/a |                    24.90x |                         6.61x |                      n/a |
-| `move_sum`                |                   3.69x |                       0.85x |                    n/a |                    14.01x |                         3.33x |                      n/a |
-| `move_var`                |                   5.66x |                       1.23x |                    n/a |                    26.11x |                         5.29x |                      n/a |
-| `nanargmax`[^5]           |                   2.19x |                       0.99x |                    n/a |                     2.08x |                         1.00x |                      n/a |
-| `nanargmin`[^5]           |                   2.52x |                       0.98x |                    n/a |                     2.14x |                         0.94x |                      n/a |
-| `nancount`                |                   0.71x |                         n/a |                  0.37x |                     2.38x |                           n/a |                    0.72x |
-| `nanmax`[^5]              |                   3.26x |                       1.00x |                  0.11x |                     3.63x |                         3.25x |                    0.11x |
-| `nanmean`                 |                   2.35x |                       0.98x |                  2.80x |                    17.80x |                         6.03x |                   17.31x |
-| `nanmin`[^5]              |                   3.25x |                       0.99x |                  0.10x |                     3.64x |                         3.26x |                    0.11x |
-| `nanquantile`             |                   0.95x |                         n/a |                  0.79x |                     5.34x |                           n/a |                    4.94x |
-| `nanstd`                  |                   1.49x |                       1.47x |                  2.72x |                    10.69x |                         9.17x |                   17.76x |
-| `nansum`                  |                   2.13x |                       0.99x |                  3.34x |                    17.31x |                         5.81x |                   17.92x |
-| `nanvar`                  |                   1.51x |                       1.48x |                  2.74x |                    10.76x |                         9.22x |                   17.15x |
+| `bfill`                   |                   1.17x |                       1.18x |                    n/a |                    12.24x |                         4.36x |                      n/a |
+| `ffill`                   |                   1.17x |                       1.12x |                    n/a |                    12.76x |                         4.34x |                      n/a |
+| `group_nanall`            |                   1.44x |                         n/a |                    n/a |                    10.84x |                           n/a |                      n/a |
+| `group_nanany`            |                   1.20x |                         n/a |                    n/a |                     5.25x |                           n/a |                      n/a |
+| `group_nanargmax`         |                   2.88x |                         n/a |                    n/a |                     9.89x |                           n/a |                      n/a |
+| `group_nanargmin`         |                   2.82x |                         n/a |                    n/a |                     9.96x |                           n/a |                      n/a |
+| `group_nancount`          |                   1.01x |                         n/a |                    n/a |                     4.70x |                           n/a |                      n/a |
+| `group_nanfirst`          |                   1.39x |                         n/a |                    n/a |                    11.80x |                           n/a |                      n/a |
+| `group_nanlast`           |                   1.16x |                         n/a |                    n/a |                     5.36x |                           n/a |                      n/a |
+| `group_nanmax`            |                   1.14x |                         n/a |                    n/a |                     5.22x |                           n/a |                      n/a |
+| `group_nanmean`           |                   1.19x |                         n/a |                    n/a |                     5.64x |                           n/a |                      n/a |
+| `group_nanmin`            |                   1.13x |                         n/a |                    n/a |                     5.26x |                           n/a |                      n/a |
+| `group_nanprod`           |                   1.15x |                         n/a |                    n/a |                     4.95x |                           n/a |                      n/a |
+| `group_nanstd`            |                   1.18x |                         n/a |                    n/a |                     5.03x |                           n/a |                      n/a |
+| `group_nansum_of_squares` |                   1.35x |                         n/a |                    n/a |                     8.11x |                           n/a |                      n/a |
+| `group_nansum`            |                   1.21x |                         n/a |                    n/a |                     5.95x |                           n/a |                      n/a |
+| `group_nanvar`            |                   1.19x |                         n/a |                    n/a |                     5.65x |                           n/a |                      n/a |
+| `move_corr`               |                  19.04x |                         n/a |                    n/a |                    92.48x |                           n/a |                      n/a |
+| `move_cov`                |                  14.58x |                         n/a |                    n/a |                    71.61x |                           n/a |                      n/a |
+| `move_exp_nancorr`        |                   6.73x |                         n/a |                    n/a |                    35.30x |                           n/a |                      n/a |
+| `move_exp_nancount`       |                   2.35x |                         n/a |                    n/a |                    10.56x |                           n/a |                      n/a |
+| `move_exp_nancov`         |                   5.77x |                         n/a |                    n/a |                    31.75x |                           n/a |                      n/a |
+| `move_exp_nanmean`        |                   2.03x |                         n/a |                    n/a |                    11.07x |                           n/a |                      n/a |
+| `move_exp_nanstd`         |                   1.89x |                         n/a |                    n/a |                    10.07x |                           n/a |                      n/a |
+| `move_exp_nansum`         |                   1.88x |                         n/a |                    n/a |                     9.70x |                           n/a |                      n/a |
+| `move_exp_nanvar`         |                   1.82x |                         n/a |                    n/a |                     9.71x |                           n/a |                      n/a |
+| `move_mean`               |                   3.82x |                       0.87x |                    n/a |                    16.61x |                         4.01x |                      n/a |
+| `move_std`                |                   5.96x |                       1.29x |                    n/a |                    24.52x |                         6.04x |                      n/a |
+| `move_sum`                |                   3.80x |                       0.83x |                    n/a |                    15.95x |                         3.70x |                      n/a |
+| `move_var`                |                   5.78x |                       1.27x |                    n/a |                    25.41x |                         5.85x |                      n/a |
+| `nanargmax`[^5]           |                   2.45x |                       1.00x |                    n/a |                     2.16x |                         1.00x |                      n/a |
+| `nanargmin`[^5]           |                   2.19x |                       1.01x |                    n/a |                     2.05x |                         1.02x |                      n/a |
+| `nancount`                |                   1.40x |                         n/a |                  1.06x |                    11.00x |                           n/a |                    4.16x |
+| `nanmax`[^5]              |                   3.26x |                       1.00x |                  0.11x |                     3.62x |                         3.24x |                    0.11x |
+| `nanmean`                 |                   2.42x |                       0.98x |                  2.83x |                    13.58x |                         4.54x |                   13.13x |
+| `nanmin`[^5]              |                   3.27x |                       1.00x |                  0.11x |                     3.62x |                         3.24x |                    0.11x |
+| `nanquantile`             |                   0.94x |                         n/a |                  0.78x |                     5.45x |                           n/a |                    5.01x |
+| `nanstd`                  |                   1.50x |                       1.51x |                  2.75x |                     8.29x |                         7.35x |                   13.27x |
+| `nansum`                  |                   2.28x |                       0.97x |                  2.52x |                    17.71x |                         6.24x |                   16.05x |
+| `nanvar`                  |                   1.50x |                       1.49x |                  2.81x |                     8.18x |                         6.97x |                   13.32x |
 
 ### Full benchmarks
 
@@ -94,191 +94,191 @@ items.
 
 | func                      |                  shape |      size | pandas | bottleneck |  numpy | numbagg | pandas_ratio | bottleneck_ratio | numpy_ratio | numbagg_ratio |
 | :------------------------ | ---------------------: | --------: | -----: | ---------: | -----: | ------: | -----------: | ---------------: | ----------: | ------------: |
-| `bfill`                   |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        1.53x |            0.03x |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   20ms |       21ms |    n/a |    18ms |        1.16x |            1.18x |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   61ms |       22ms |    n/a |     5ms |       11.31x |            4.05x |         n/a |         1.00x |
+| `bfill`                   |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        1.59x |            0.03x |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   20ms |       20ms |    n/a |    17ms |        1.17x |            1.18x |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   57ms |       20ms |    n/a |     5ms |       12.24x |            4.36x |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       21ms |    n/a |     5ms |          n/a |            4.40x |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |      252ms |    n/a |    43ms |          n/a |            5.86x |         n/a |         1.00x |
-| `ffill`                   |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        1.54x |            0.02x |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   20ms |       20ms |    n/a |    17ms |        1.21x |            1.18x |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   57ms |       20ms |    n/a |     5ms |       12.60x |            4.39x |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       20ms |    n/a |     5ms |          n/a |            3.85x |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |      236ms |    n/a |    42ms |          n/a |            5.59x |         n/a |         1.00x |
-| `group_nanall`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.85x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   67ms |        n/a |    n/a |    47ms |        1.41x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   17ms |        n/a |    n/a |     2ms |       10.70x |              n/a |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |      248ms |    n/a |    44ms |          n/a |            5.70x |         n/a |         1.00x |
+| `ffill`                   |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        1.53x |            0.02x |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   20ms |       19ms |    n/a |    17ms |        1.17x |            1.12x |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   56ms |       19ms |    n/a |     4ms |       12.76x |            4.34x |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       19ms |    n/a |     4ms |          n/a |            4.33x |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |      219ms |    n/a |    42ms |          n/a |            5.25x |         n/a |         1.00x |
+| `group_nanall`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.79x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   68ms |        n/a |    n/a |    47ms |        1.44x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   17ms |        n/a |    n/a |     2ms |       10.84x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     1ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nanany`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.84x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   67ms |        n/a |    n/a |    57ms |        1.16x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   17ms |        n/a |    n/a |     3ms |        5.49x |              n/a |         n/a |         1.00x |
+| `group_nanany`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.78x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   68ms |        n/a |    n/a |    56ms |        1.20x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   18ms |        n/a |    n/a |     3ms |        5.25x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     3ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nanargmax`         |                (1000,) |      1000 |    1ms |        n/a |    n/a |     0ms |       16.59x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |  164ms |        n/a |    n/a |    58ms |        2.83x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   39ms |        n/a |    n/a |     3ms |       11.44x |              n/a |         n/a |         1.00x |
+| `group_nanargmax`         |                (1000,) |      1000 |    1ms |        n/a |    n/a |     0ms |       17.60x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |  171ms |        n/a |    n/a |    59ms |        2.88x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   40ms |        n/a |    n/a |     4ms |        9.89x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     4ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nanargmin`         |                (1000,) |      1000 |    1ms |        n/a |    n/a |     0ms |       17.93x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |  166ms |        n/a |    n/a |    58ms |        2.85x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   39ms |        n/a |    n/a |     4ms |       11.18x |              n/a |         n/a |         1.00x |
+| `group_nanargmin`         |                (1000,) |      1000 |    1ms |        n/a |    n/a |     0ms |       17.56x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |  166ms |        n/a |    n/a |    59ms |        2.82x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   41ms |        n/a |    n/a |     4ms |        9.96x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     4ms |          n/a |              n/a |         n/a |         1.00x |
 | `group_nancount`          |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.68x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   56ms |        n/a |    n/a |    56ms |        1.01x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   15ms |        n/a |    n/a |     3ms |        4.62x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   56ms |        n/a |    n/a |    55ms |        1.01x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   15ms |        n/a |    n/a |     3ms |        4.70x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     3ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nanfirst`          |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.86x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   64ms |        n/a |    n/a |    46ms |        1.38x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   16ms |        n/a |    n/a |     1ms |       11.76x |              n/a |         n/a |         1.00x |
+| `group_nanfirst`          |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.88x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   63ms |        n/a |    n/a |    45ms |        1.39x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   15ms |        n/a |    n/a |     1ms |       11.80x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     1ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nanlast`           |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.85x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   65ms |        n/a |    n/a |    58ms |        1.12x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   15ms |        n/a |    n/a |     3ms |        4.66x |              n/a |         n/a |         1.00x |
+| `group_nanlast`           |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.87x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   62ms |        n/a |    n/a |    53ms |        1.16x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   15ms |        n/a |    n/a |     3ms |        5.36x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     2ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nanmax`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.81x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   67ms |        n/a |    n/a |    60ms |        1.12x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   17ms |        n/a |    n/a |     4ms |        4.54x |              n/a |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     4ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nanmean`           |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.43x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   70ms |        n/a |    n/a |    60ms |        1.16x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   19ms |        n/a |    n/a |     4ms |        5.28x |              n/a |         n/a |         1.00x |
+| `group_nanmax`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.89x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   66ms |        n/a |    n/a |    57ms |        1.14x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   17ms |        n/a |    n/a |     3ms |        5.22x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     3ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nanmin`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.87x |              n/a |         n/a |         1.00x |
+| `group_nanmean`           |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.81x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   67ms |        n/a |    n/a |    57ms |        1.19x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   19ms |        n/a |    n/a |     3ms |        5.64x |              n/a |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     3ms |          n/a |              n/a |         n/a |         1.00x |
+| `group_nanmin`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.84x |              n/a |         n/a |         1.00x |
 |                           |            (10000000,) |  10000000 |   66ms |        n/a |    n/a |    58ms |        1.13x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   17ms |        n/a |    n/a |     4ms |        4.52x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   17ms |        n/a |    n/a |     3ms |        5.26x |              n/a |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     3ms |          n/a |              n/a |         n/a |         1.00x |
+| `group_nanprod`           |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.86x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   63ms |        n/a |    n/a |    55ms |        1.15x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   16ms |        n/a |    n/a |     3ms |        4.95x |              n/a |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     3ms |          n/a |              n/a |         n/a |         1.00x |
+| `group_nanstd`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.73x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   70ms |        n/a |    n/a |    59ms |        1.18x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   20ms |        n/a |    n/a |     4ms |        5.03x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     4ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nanprod`           |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.09x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   64ms |        n/a |    n/a |    58ms |        1.09x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   16ms |        n/a |    n/a |     3ms |        4.93x |              n/a |         n/a |         1.00x |
+| `group_nansum`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.89x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   67ms |        n/a |    n/a |    56ms |        1.21x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   19ms |        n/a |    n/a |     3ms |        5.95x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     3ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nanstd`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.89x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   74ms |        n/a |    n/a |    61ms |        1.21x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   20ms |        n/a |    n/a |     4ms |        4.82x |              n/a |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     4ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nansum`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.87x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   69ms |        n/a |    n/a |    56ms |        1.22x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   19ms |        n/a |    n/a |     4ms |        5.18x |              n/a |         n/a |         1.00x |
+| `group_nanvar`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.71x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   69ms |        n/a |    n/a |    58ms |        1.19x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   20ms |        n/a |    n/a |     4ms |        5.65x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     3ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nanvar`            |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.64x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   70ms |        n/a |    n/a |    59ms |        1.19x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   21ms |        n/a |    n/a |     4ms |        4.86x |              n/a |         n/a |         1.00x |
+| `group_nansum_of_squares` |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        2.36x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   75ms |        n/a |    n/a |    55ms |        1.35x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   26ms |        n/a |    n/a |     3ms |        8.11x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     3ms |          n/a |              n/a |         n/a |         1.00x |
-| `group_nansum_of_squares` |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        0.52x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |  125ms |        n/a |    n/a |    92ms |        1.36x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   33ms |        n/a |    n/a |    13ms |        2.62x |              n/a |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     7ms |          n/a |              n/a |         n/a |         1.00x |
-| `move_corr`               |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |       10.60x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |  938ms |        n/a |    n/a |    48ms |       19.56x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |  874ms |        n/a |    n/a |    11ms |       82.74x |              n/a |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |    10ms |          n/a |              n/a |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    79ms |          n/a |              n/a |         n/a |         1.00x |
-| `move_cov`                |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        9.43x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |  624ms |        n/a |    n/a |    43ms |       14.46x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |  631ms |        n/a |    n/a |     9ms |       68.84x |              n/a |         n/a |         1.00x |
+| `move_corr`               |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |       10.85x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |  909ms |        n/a |    n/a |    48ms |       19.04x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |  869ms |        n/a |    n/a |     9ms |       92.48x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     9ms |          n/a |              n/a |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    76ms |          n/a |              n/a |         n/a |         1.00x |
-| `move_mean`               |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        1.84x |            0.03x |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |  123ms |       28ms |    n/a |    32ms |        3.85x |            0.88x |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |  120ms |       28ms |    n/a |     7ms |       17.69x |            4.16x |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       28ms |    n/a |     8ms |          n/a |            3.62x |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |      306ms |    n/a |    64ms |          n/a |            4.75x |         n/a |         1.00x |
-| `move_std`                |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        2.17x |            0.08x |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |  179ms |       40ms |    n/a |    30ms |        5.96x |            1.32x |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |  162ms |       43ms |    n/a |     6ms |       24.90x |            6.61x |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       40ms |    n/a |     8ms |          n/a |            5.23x |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |      427ms |    n/a |    68ms |          n/a |            6.25x |         n/a |         1.00x |
-| `move_sum`                |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        1.80x |            0.02x |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |  120ms |       28ms |    n/a |    32ms |        3.69x |            0.85x |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |  113ms |       27ms |    n/a |     8ms |       14.01x |            3.33x |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       27ms |    n/a |     8ms |          n/a |            3.40x |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |      290ms |    n/a |    62ms |          n/a |            4.66x |         n/a |         1.00x |
-| `move_var`                |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        1.98x |            0.08x |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |  171ms |       37ms |    n/a |    30ms |        5.66x |            1.23x |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |  182ms |       37ms |    n/a |     7ms |       26.11x |            5.29x |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       37ms |    n/a |     6ms |          n/a |            5.81x |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |      398ms |    n/a |    56ms |          n/a |            7.14x |         n/a |         1.00x |
-| `move_exp_nancorr`        |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        6.91x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |  485ms |        n/a |    n/a |    69ms |        6.99x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |  483ms |        n/a |    n/a |    16ms |       30.75x |              n/a |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |    15ms |          n/a |              n/a |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |   133ms |          n/a |              n/a |         n/a |         1.00x |
-| `move_exp_nancount`       |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        2.02x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   77ms |        n/a |    n/a |    33ms |        2.36x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   69ms |        n/a |    n/a |     7ms |       10.49x |              n/a |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     7ms |          n/a |              n/a |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    59ms |          n/a |              n/a |         n/a |         1.00x |
-| `move_exp_nancov`         |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        6.78x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |  322ms |        n/a |    n/a |    53ms |        6.12x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |  370ms |        n/a |    n/a |    12ms |       30.65x |              n/a |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |    12ms |          n/a |              n/a |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |   113ms |          n/a |              n/a |         n/a |         1.00x |
-| `move_exp_nanmean`        |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.41x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   72ms |        n/a |    n/a |    33ms |        2.17x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   76ms |        n/a |    n/a |     7ms |       10.67x |              n/a |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    79ms |          n/a |              n/a |         n/a |         1.00x |
+| `move_cov`                |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |       10.05x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |  623ms |        n/a |    n/a |    43ms |       14.58x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |  603ms |        n/a |    n/a |     8ms |       71.61x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     8ms |          n/a |              n/a |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    60ms |          n/a |              n/a |         n/a |         1.00x |
-| `move_exp_nanstd`         |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        2.30x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   87ms |        n/a |    n/a |    46ms |        1.87x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   94ms |        n/a |    n/a |     9ms |        9.98x |              n/a |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |    10ms |          n/a |              n/a |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    77ms |          n/a |              n/a |         n/a |         1.00x |
-| `move_exp_nansum`         |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.27x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   64ms |        n/a |    n/a |    34ms |        1.90x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   69ms |        n/a |    n/a |     8ms |        8.17x |              n/a |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    72ms |          n/a |              n/a |         n/a |         1.00x |
+| `move_mean`               |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        1.84x |            0.03x |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |  120ms |       27ms |    n/a |    31ms |        3.82x |            0.87x |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |  113ms |       27ms |    n/a |     7ms |       16.61x |            4.01x |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       27ms |    n/a |     7ms |          n/a |            3.96x |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |      296ms |    n/a |    58ms |          n/a |            5.08x |         n/a |         1.00x |
+| `move_std`                |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        2.21x |            0.08x |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |  178ms |       39ms |    n/a |    30ms |        5.96x |            1.29x |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |  157ms |       39ms |    n/a |     6ms |       24.52x |            6.04x |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       39ms |    n/a |     7ms |          n/a |            5.88x |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |      411ms |    n/a |    58ms |          n/a |            7.13x |         n/a |         1.00x |
+| `move_sum`                |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        1.81x |            0.02x |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |  121ms |       26ms |    n/a |    32ms |        3.80x |            0.83x |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |  113ms |       26ms |    n/a |     7ms |       15.95x |            3.70x |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       26ms |    n/a |     7ms |          n/a |            3.59x |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |      281ms |    n/a |    59ms |          n/a |            4.77x |         n/a |         1.00x |
+| `move_var`                |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |        2.04x |            0.08x |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |  168ms |       37ms |    n/a |    29ms |        5.78x |            1.27x |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |  161ms |       37ms |    n/a |     6ms |       25.41x |            5.85x |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       37ms |    n/a |     6ms |          n/a |            5.85x |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |      398ms |    n/a |    56ms |          n/a |            7.07x |         n/a |         1.00x |
+| `move_exp_nancorr`        |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        7.27x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |  464ms |        n/a |    n/a |    69ms |        6.73x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |  471ms |        n/a |    n/a |    13ms |       35.30x |              n/a |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |    13ms |          n/a |              n/a |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |   111ms |          n/a |              n/a |         n/a |         1.00x |
+| `move_exp_nancount`       |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        2.04x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   77ms |        n/a |    n/a |    33ms |        2.35x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   69ms |        n/a |    n/a |     7ms |       10.56x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     6ms |          n/a |              n/a |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    61ms |          n/a |              n/a |         n/a |         1.00x |
-| `move_exp_nanvar`         |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.41x |              n/a |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   78ms |        n/a |    n/a |    43ms |        1.81x |              n/a |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   88ms |        n/a |    n/a |    10ms |        8.84x |              n/a |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    59ms |          n/a |              n/a |         n/a |         1.00x |
+| `move_exp_nancov`         |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        7.07x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |  298ms |        n/a |    n/a |    52ms |        5.77x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |  333ms |        n/a |    n/a |    10ms |       31.75x |              n/a |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |    10ms |          n/a |              n/a |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    87ms |          n/a |              n/a |         n/a |         1.00x |
+| `move_exp_nanmean`        |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.40x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   67ms |        n/a |    n/a |    33ms |        2.03x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   74ms |        n/a |    n/a |     7ms |       11.07x |              n/a |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     7ms |          n/a |              n/a |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    60ms |          n/a |              n/a |         n/a |         1.00x |
+| `move_exp_nanstd`         |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        2.33x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   88ms |        n/a |    n/a |    46ms |        1.89x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   95ms |        n/a |    n/a |     9ms |       10.07x |              n/a |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     9ms |          n/a |              n/a |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    78ms |          n/a |              n/a |         n/a |         1.00x |
+| `move_exp_nansum`         |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.36x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   62ms |        n/a |    n/a |    33ms |        1.88x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   71ms |        n/a |    n/a |     7ms |        9.70x |              n/a |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     6ms |          n/a |              n/a |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    60ms |          n/a |              n/a |         n/a |         1.00x |
+| `move_exp_nanvar`         |                (1000,) |      1000 |    0ms |        n/a |    n/a |     0ms |        1.40x |              n/a |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   77ms |        n/a |    n/a |    42ms |        1.82x |              n/a |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   84ms |        n/a |    n/a |     9ms |        9.71x |              n/a |         n/a |         1.00x |
 |                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    n/a |     9ms |          n/a |              n/a |         n/a |         1.00x |
 |                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |    n/a |    73ms |          n/a |              n/a |         n/a |         1.00x |
-| `nanargmax`[^5]           |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |       12.97x |            0.21x |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   28ms |       13ms |    n/a |    13ms |        2.19x |            0.99x |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   26ms |       12ms |    n/a |    12ms |        2.08x |            1.00x |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       14ms |    n/a |    13ms |          n/a |            1.04x |         n/a |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |      145ms |    n/a |   133ms |          n/a |            1.09x |         n/a |         1.00x |
-| `nanargmin`[^5]           |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |       13.63x |            0.21x |         n/a |         1.00x |
-|                           |            (10000000,) |  10000000 |   32ms |       12ms |    n/a |    13ms |        2.52x |            0.98x |         n/a |         1.00x |
-|                           |          (100, 100000) |  10000000 |   28ms |       12ms |    n/a |    13ms |        2.14x |            0.94x |         n/a |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       16ms |    n/a |    14ms |          n/a |            1.17x |         n/a |         1.00x |
+| `nanargmax`[^5]           |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |       13.07x |            0.21x |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   31ms |       12ms |    n/a |    12ms |        2.45x |            1.00x |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   28ms |       13ms |    n/a |    13ms |        2.16x |            1.00x |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       13ms |    n/a |    13ms |          n/a |            1.05x |         n/a |         1.00x |
 |                           |      (100, 1000, 1000) | 100000000 |    n/a |      133ms |    n/a |   127ms |          n/a |            1.05x |         n/a |         1.00x |
-| `nancount`                |                (1000,) |      1000 |    0ms |        n/a |    0ms |     1ms |        0.10x |              n/a |       0.00x |         1.00x |
-|                           |            (10000000,) |  10000000 |    7ms |        n/a |    3ms |     9ms |        0.71x |              n/a |       0.37x |         1.00x |
-|                           |          (100, 100000) |  10000000 |   11ms |        n/a |    3ms |     5ms |        2.38x |              n/a |       0.72x |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    3ms |     1ms |          n/a |              n/a |       3.43x |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |   41ms |    25ms |          n/a |              n/a |       1.60x |         1.00x |
-| `nanmax`[^5]              |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        8.16x |            0.21x |       0.37x |         1.00x |
-|                           |            (10000000,) |  10000000 |   41ms |       12ms |    1ms |    12ms |        3.26x |            1.00x |       0.11x |         1.00x |
-|                           |          (100, 100000) |  10000000 |   45ms |       40ms |    1ms |    12ms |        3.63x |            3.25x |       0.11x |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       40ms |    1ms |    12ms |          n/a |            3.30x |       0.12x |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |      401ms |   14ms |   121ms |          n/a |            3.31x |       0.12x |         1.00x |
-| `nanmean`                 |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        1.34x |            0.02x |       0.20x |         1.00x |
-|                           |            (10000000,) |  10000000 |   22ms |        9ms |   27ms |    10ms |        2.35x |            0.98x |       2.80x |         1.00x |
-|                           |          (100, 100000) |  10000000 |   28ms |        9ms |   27ms |     2ms |       17.80x |            6.03x |      17.31x |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        9ms |   26ms |     2ms |          n/a |            5.88x |      17.12x |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |       90ms |  297ms |    14ms |          n/a |            6.60x |      21.79x |         1.00x |
-| `nanmin`[^5]              |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        8.14x |            0.21x |       0.37x |         1.00x |
-|                           |            (10000000,) |  10000000 |   41ms |       12ms |    1ms |    13ms |        3.25x |            0.99x |       0.10x |         1.00x |
-|                           |          (100, 100000) |  10000000 |   45ms |       41ms |    1ms |    12ms |        3.64x |            3.26x |       0.11x |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       40ms |    1ms |    12ms |          n/a |            3.30x |       0.12x |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |      406ms |   14ms |   122ms |          n/a |            3.33x |       0.11x |         1.00x |
-| `nanquantile`             |                (1000,) |      1000 |    0ms |        n/a |    0ms |     0ms |        1.42x |              n/a |       0.55x |         1.00x |
-|                           |            (10000000,) |  10000000 |  189ms |        n/a |  158ms |   199ms |        0.95x |              n/a |       0.79x |         1.00x |
-|                           |          (100, 100000) |  10000000 |  197ms |        n/a |  182ms |    37ms |        5.34x |              n/a |       4.94x |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |  426ms |    38ms |          n/a |              n/a |      11.27x |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a | 4308ms |   345ms |          n/a |              n/a |      12.48x |         1.00x |
-| `nanstd`                  |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        1.07x |            0.06x |       0.46x |         1.00x |
-|                           |            (10000000,) |  10000000 |   28ms |       28ms |   52ms |    19ms |        1.49x |            1.47x |       2.72x |         1.00x |
-|                           |          (100, 100000) |  10000000 |   33ms |       28ms |   55ms |     3ms |       10.69x |            9.17x |      17.76x |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       28ms |   55ms |     3ms |          n/a |            8.48x |      16.69x |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |      279ms |  586ms |    27ms |          n/a |           10.40x |      21.87x |         1.00x |
-| `nansum`                  |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        1.31x |            0.02x |       0.08x |         1.00x |
-|                           |            (10000000,) |  10000000 |   20ms |        9ms |   32ms |    10ms |        2.13x |            0.99x |       3.34x |         1.00x |
-|                           |          (100, 100000) |  10000000 |   28ms |        9ms |   29ms |     2ms |       17.31x |            5.81x |      17.92x |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       10ms |   24ms |     8ms |          n/a |            1.15x |       2.86x |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |       95ms |  265ms |    17ms |          n/a |            5.67x |      15.78x |         1.00x |
-| `nanvar`                  |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        1.07x |            0.06x |       0.45x |         1.00x |
-|                           |            (10000000,) |  10000000 |   28ms |       28ms |   52ms |    19ms |        1.51x |            1.48x |       2.74x |         1.00x |
-|                           |          (100, 100000) |  10000000 |   33ms |       28ms |   52ms |     3ms |       10.76x |            9.22x |      17.15x |         1.00x |
-|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       28ms |   57ms |     3ms |          n/a |            8.40x |      17.02x |         1.00x |
-|                           |      (100, 1000, 1000) | 100000000 |    n/a |      278ms |  580ms |    26ms |          n/a |           10.78x |      22.46x |         1.00x |
+| `nanargmin`[^5]           |                (1000,) |      1000 |    0ms |        0ms |    n/a |     0ms |       12.72x |            0.21x |         n/a |         1.00x |
+|                           |            (10000000,) |  10000000 |   27ms |       13ms |    n/a |    12ms |        2.19x |            1.01x |         n/a |         1.00x |
+|                           |          (100, 100000) |  10000000 |   26ms |       13ms |    n/a |    12ms |        2.05x |            1.02x |         n/a |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       13ms |    n/a |    13ms |          n/a |            1.05x |         n/a |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |      135ms |    n/a |   129ms |          n/a |            1.05x |         n/a |         1.00x |
+| `nancount`                |                (1000,) |      1000 |    0ms |        n/a |    0ms |     0ms |        2.24x |              n/a |       0.05x |         1.00x |
+|                           |            (10000000,) |  10000000 |    5ms |        n/a |    4ms |     3ms |        1.40x |              n/a |       1.06x |         1.00x |
+|                           |          (100, 100000) |  10000000 |    9ms |        n/a |    3ms |     1ms |       11.00x |              n/a |       4.16x |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |    4ms |     1ms |          n/a |              n/a |       3.58x |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a |   45ms |     7ms |          n/a |              n/a |       6.74x |         1.00x |
+| `nanmax`[^5]              |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        8.21x |            0.21x |       0.38x |         1.00x |
+|                           |            (10000000,) |  10000000 |   41ms |       12ms |    1ms |    13ms |        3.26x |            1.00x |       0.11x |         1.00x |
+|                           |          (100, 100000) |  10000000 |   45ms |       41ms |    1ms |    13ms |        3.62x |            3.24x |       0.11x |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       40ms |    1ms |    12ms |          n/a |            3.31x |       0.12x |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |      402ms |   15ms |   121ms |          n/a |            3.31x |       0.12x |         1.00x |
+| `nanmean`                 |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        1.32x |            0.02x |       0.20x |         1.00x |
+|                           |            (10000000,) |  10000000 |   23ms |        9ms |   27ms |    10ms |        2.42x |            0.98x |       2.83x |         1.00x |
+|                           |          (100, 100000) |  10000000 |   28ms |        9ms |   27ms |     2ms |       13.58x |            4.54x |      13.13x |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        9ms |   27ms |     2ms |          n/a |            4.56x |      13.69x |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |       91ms |  310ms |    17ms |          n/a |            5.39x |      18.39x |         1.00x |
+| `nanmin`[^5]              |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        8.09x |            0.21x |       0.38x |         1.00x |
+|                           |            (10000000,) |  10000000 |   41ms |       12ms |    1ms |    13ms |        3.27x |            1.00x |       0.11x |         1.00x |
+|                           |          (100, 100000) |  10000000 |   45ms |       41ms |    1ms |    13ms |        3.62x |            3.24x |       0.11x |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       40ms |    1ms |    12ms |          n/a |            3.28x |       0.12x |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |      401ms |   15ms |   122ms |          n/a |            3.30x |       0.12x |         1.00x |
+| `nanquantile`             |                (1000,) |      1000 |    0ms |        n/a |    0ms |     0ms |        1.46x |              n/a |       0.57x |         1.00x |
+|                           |            (10000000,) |  10000000 |  186ms |        n/a |  155ms |   198ms |        0.94x |              n/a |       0.78x |         1.00x |
+|                           |          (100, 100000) |  10000000 |  197ms |        n/a |  181ms |    36ms |        5.45x |              n/a |       5.01x |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        n/a |  425ms |    34ms |          n/a |              n/a |      12.50x |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |        n/a | 4254ms |   331ms |          n/a |              n/a |      12.85x |         1.00x |
+| `nanstd`                  |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        1.06x |            0.06x |       0.46x |         1.00x |
+|                           |            (10000000,) |  10000000 |   29ms |       29ms |   53ms |    19ms |        1.50x |            1.51x |       2.75x |         1.00x |
+|                           |          (100, 100000) |  10000000 |   33ms |       29ms |   53ms |     4ms |        8.29x |            7.35x |      13.27x |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       28ms |   55ms |     4ms |          n/a |            7.25x |      14.43x |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |      294ms |  600ms |    37ms |          n/a |            8.02x |      16.35x |         1.00x |
+| `nansum`                  |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        1.28x |            0.02x |       0.08x |         1.00x |
+|                           |            (10000000,) |  10000000 |   22ms |        9ms |   24ms |    10ms |        2.28x |            0.97x |       2.52x |         1.00x |
+|                           |          (100, 100000) |  10000000 |   27ms |        9ms |   24ms |     2ms |       17.71x |            6.24x |      16.05x |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |        9ms |   25ms |     1ms |          n/a |            6.05x |      16.66x |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |       90ms |  282ms |    13ms |          n/a |            6.71x |      21.07x |         1.00x |
+| `nanvar`                  |                (1000,) |      1000 |    0ms |        0ms |    0ms |     0ms |        1.08x |            0.06x |       0.45x |         1.00x |
+|                           |            (10000000,) |  10000000 |   28ms |       28ms |   53ms |    19ms |        1.50x |            1.49x |       2.81x |         1.00x |
+|                           |          (100, 100000) |  10000000 |   33ms |       28ms |   54ms |     4ms |        8.18x |            6.97x |      13.32x |         1.00x |
+|                           | (10, 10, 10, 10, 1000) |  10000000 |    n/a |       28ms |   56ms |     4ms |          n/a |            7.13x |      14.28x |         1.00x |
+|                           |      (100, 1000, 1000) | 100000000 |    n/a |      281ms |  601ms |    32ms |          n/a |            8.71x |      18.65x |         1.00x |
 
 </details>
 
@@ -286,21 +286,24 @@ items.
 
 [^1]:
     Benchmarks were run on a Mac M1 laptop in December 2023 on numbagg's HEAD,
-    pandas 2.1.1, bottleneck 1.3.7. They run in CI, though GHA's low CPU count
-    means we don't see the full benefits of parallelization.
+    pandas 2.1.1, bottleneck 1.3.7, numpy 1.25.2, with `python
+numbagg/test/run_benchmarks.py -- --benchmark-max-time=10`. They run in CI,
+    though GHA's low CPU count means we don't see the full benefits of
+    parallelization.
 
 [^2]:
     While we separate the setup and the running of the functions, pandas still
     needs to do some work to create its result dataframe, and numbagg does some
-    checks in python which bottleneck does in C or doesn't do. So we focus on
-    the benchmarks for larger arrays in order to reduce that impact. Any
-    contributions to improve the benchmarks are welcome.
+    checks in python which bottleneck does in C or doesn't do. So use benchmarks
+    on larger arrays for our summary so we can focus on the computational speed,
+    which doesn't asymptote away. Any contributions to improve the benchmarks are
+    welcome.
 
 [^3]:
-    Pandas doesn't have an equivalent `move_exp_nancount` function, so this is
-    compared to a function which uses its `sum` function on an array of `1`s.
-    Similarly for `group_nansum_of_squares`, this requires two separate
-    operations in pandas.
+    In some instances, a library won't have the exact function — for example,
+    pandas doesn't have an equivalent `move_exp_nancount` function, so we use
+    its `sum` function on an array of `1`s. Similarly for
+    `group_nansum_of_squares`, we use two separate operations.
 
 [^4]:
     `anynan` & `allnan` are also functions in numbagg, but not listed here as they


### PR DESCRIPTION
This is the output from `python numbagg/test/run_benchmarks.py -- --benchmark-max-time=10` and ensuring nothing else is running
