### PR TITLE
Optional fastmath optimizations via env var

### DIFF
--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -4,7 +4,9 @@ import abc
 import functools
 import itertools
 import logging
+import os
 import threading
+import warnings
 from collections.abc import Iterable
 from functools import cache, cached_property
 from typing import Any, Callable, Literal, TypeVar
@@ -24,6 +26,18 @@ def ndim(arg):
 
 
 _ALPHABET = "abcdefghijkmnopqrstuvwxyz"
+
+if os.getenv("NUMBAGG_FASTMATH", 'False').lower() in ('true', '1', 't'):
+    _FASTMATH = True
+    warnings.warn(
+        "Fastmath optimizations are enabled in numbagg. "
+        "This may result in different results than numpy due to reduced precision.",
+        UserWarning
+    )
+else:
+    _FASTMATH = False
+
+_FASTMATH_FLAGS = {"nsz", "arcp", "contract", "afn", "reassoc"}
 
 
 def _gufunc_arg_str(arg):
@@ -104,6 +118,7 @@ class NumbaBase:
             nopython=True,
             target=target,
             cache=self.cache,
+            fastmath=_FASTMATH_FLAGS if _FASTMATH else False,
         )
         return vectorize(self.func)
 
@@ -179,6 +194,7 @@ class ndaggregate(NumbaBaseSimple):
             nopython=True,
             target=target,
             cache=self.cache,
+            fastmath=_FASTMATH_FLAGS if _FASTMATH else False,
         )
         return vectorize(self.func)
 
@@ -426,6 +442,7 @@ class groupndreduce(NumbaBase):
             nopython=True,
             target=target,
             cache=self.cache,
+            fastmath=_FASTMATH_FLAGS if _FASTMATH else False,
         )
         return vectorize(self.func)
 
@@ -602,6 +619,7 @@ class ndquantile(NumbaBase):
             nopython=True,
             target=target,
             cache=self.cache,
+            fastmath=_FASTMATH_FLAGS if _FASTMATH else False,
         )
         return vectorize(self.func)
 
@@ -694,7 +712,7 @@ class ndreduce(NumbaBase):
 
         # Can't use `cache=True` because of the dynamic ast transformation
         vectorize = numba.guvectorize(
-            numba_sig, gufunc_sig, nopython=True, target=target
+            numba_sig, gufunc_sig, nopython=True, target=target, fastmath=_FASTMATH_FLAGS if _FASTMATH else False,
         )
         return vectorize(self.transformed_func)
 

--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -37,7 +37,7 @@ if os.getenv("NUMBAGG_FASTMATH", "False").lower() in ("true", "1", "t"):
         UserWarning,
     )
 else:
-    _FASTMATH = False
+    _FASTMATH = False  # type: ignore[assignment]
 
 
 def _gufunc_arg_str(arg):

--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -27,18 +27,17 @@ def ndim(arg):
 
 _ALPHABET = "abcdefghijkmnopqrstuvwxyz"
 
-if os.getenv("NUMBAGG_FASTMATH", 'False').lower() in ('true', '1', 't'):
+if os.getenv("NUMBAGG_FASTMATH", "False").lower() in ("true", "1", "t"):
     # we exclude the "no nans" and "no infs" flags
     # see https://llvm.org/docs/LangRef.html#fast-math-flags
     _FASTMATH = {"nsz", "arcp", "contract", "afn", "reassoc"}
     warnings.warn(
         "Fastmath optimizations are enabled in numbagg. "
         "This may result in different results than numpy due to reduced precision.",
-        UserWarning
+        UserWarning,
     )
 else:
     _FASTMATH = False
-
 
 
 def _gufunc_arg_str(arg):
@@ -713,7 +712,11 @@ class ndreduce(NumbaBase):
 
         # Can't use `cache=True` because of the dynamic ast transformation
         vectorize = numba.guvectorize(
-            numba_sig, gufunc_sig, nopython=True, target=target, fastmath=_FASTMATH,
+            numba_sig,
+            gufunc_sig,
+            nopython=True,
+            target=target,
+            fastmath=_FASTMATH,
         )
         return vectorize(self.transformed_func)
 

--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -28,7 +28,9 @@ def ndim(arg):
 _ALPHABET = "abcdefghijkmnopqrstuvwxyz"
 
 if os.getenv("NUMBAGG_FASTMATH", 'False').lower() in ('true', '1', 't'):
-    _FASTMATH = True
+    # we exclude the "no nans" and "no infs" flags
+    # see https://llvm.org/docs/LangRef.html#fast-math-flags
+    _FASTMATH = {"nsz", "arcp", "contract", "afn", "reassoc"}
     warnings.warn(
         "Fastmath optimizations are enabled in numbagg. "
         "This may result in different results than numpy due to reduced precision.",
@@ -37,7 +39,6 @@ if os.getenv("NUMBAGG_FASTMATH", 'False').lower() in ('true', '1', 't'):
 else:
     _FASTMATH = False
 
-_FASTMATH_FLAGS = {"nsz", "arcp", "contract", "afn", "reassoc"}
 
 
 def _gufunc_arg_str(arg):
@@ -118,7 +119,7 @@ class NumbaBase:
             nopython=True,
             target=target,
             cache=self.cache,
-            fastmath=_FASTMATH_FLAGS if _FASTMATH else False,
+            fastmath=_FASTMATH,
         )
         return vectorize(self.func)
 
@@ -194,7 +195,7 @@ class ndaggregate(NumbaBaseSimple):
             nopython=True,
             target=target,
             cache=self.cache,
-            fastmath=_FASTMATH_FLAGS if _FASTMATH else False,
+            fastmath=_FASTMATH,
         )
         return vectorize(self.func)
 
@@ -442,7 +443,7 @@ class groupndreduce(NumbaBase):
             nopython=True,
             target=target,
             cache=self.cache,
-            fastmath=_FASTMATH_FLAGS if _FASTMATH else False,
+            fastmath=_FASTMATH,
         )
         return vectorize(self.func)
 
@@ -619,7 +620,7 @@ class ndquantile(NumbaBase):
             nopython=True,
             target=target,
             cache=self.cache,
-            fastmath=_FASTMATH_FLAGS if _FASTMATH else False,
+            fastmath=_FASTMATH,
         )
         return vectorize(self.func)
 
@@ -712,7 +713,7 @@ class ndreduce(NumbaBase):
 
         # Can't use `cache=True` because of the dynamic ast transformation
         vectorize = numba.guvectorize(
-            numba_sig, gufunc_sig, nopython=True, target=target, fastmath=_FASTMATH_FLAGS if _FASTMATH else False,
+            numba_sig, gufunc_sig, nopython=True, target=target, fastmath=_FASTMATH,
         )
         return vectorize(self.transformed_func)
 

--- a/numbagg/funcs.py
+++ b/numbagg/funcs.py
@@ -51,6 +51,7 @@ def nancount(a, out):
             non_missing += 1
     out[0] = non_missing
 
+
 @ndaggregate.wrap(
     signature=[
         (int32[:], int32[:]),
@@ -84,6 +85,7 @@ def nanmean(a, out):
         out[0] = asum / count
     else:
         out[0] = np.nan
+
 
 @ndaggregate.wrap(
     signature=[

--- a/numbagg/funcs.py
+++ b/numbagg/funcs.py
@@ -5,14 +5,6 @@ from numba import bool_, float32, float64, int32, int64
 
 from numbagg.decorators import ndaggregate, ndfill, ndquantile, ndreduce
 
-# @ndreduce.wrap([bool_(int32), bool_(int64), bool_(float32), bool_(float64)])
-# def allnan(a):
-#     f = True
-#     for ai in a.flat:
-#         if not np.isnan(ai):
-#             f = False
-#             break
-#     return f
 
 @ndaggregate.wrap(
     signature=[
@@ -29,15 +21,6 @@ def allnan(a, out):
             return
 
 
-# @ndreduce.wrap([bool_(int32), bool_(int64), bool_(float32), bool_(float64)])
-# def anynan(a):
-#     f = False
-#     for ai in a.flat:
-#         if np.isnan(ai):
-#             f = True
-#             break
-#     return f
-
 @ndaggregate.wrap(
     signature=[
         (int32[:], bool_[:]),
@@ -47,18 +30,11 @@ def allnan(a, out):
     ]
 )
 def anynan(a, out):
-    for ai in a:
+    for ai in a.flat:
         if np.isnan(ai):
             out[0] = True
             return
 
-# @ndreduce.wrap([int64(int32), int64(int64), int64(float32), int64(float64)])
-# def nancount(a):
-#     non_missing = 0
-#     for ai in a.flat:
-#         if not np.isnan(ai):
-#             non_missing += 1
-#     return non_missing
 
 @ndaggregate.wrap(
     signature=[
@@ -70,18 +46,10 @@ def anynan(a, out):
 )
 def nancount(a, out):
     non_missing = 0
-    for ai in a:
+    for ai in a.flat:
         if not np.isnan(ai):
             non_missing += 1
     out[0] = non_missing
-
-# @ndreduce.wrap([int32(int32), int64(int64), float32(float32), float64(float64)])
-# def nansum(a):
-#     asum = 0
-#     for ai in a.flat:
-#         if not np.isnan(ai):
-#             asum += ai
-#     return asum
 
 @ndaggregate.wrap(
     signature=[
@@ -93,23 +61,10 @@ def nancount(a, out):
 )
 def nansum(a, out):
     asum = a.dtype.type(0)
-    for ai in a:
-        if ai == ai:
+    for ai in a.flat:
+        if not np.isnan(ai):
             asum += ai
     out[0] = asum
-
-# @ndreduce.wrap([float32(float32), float64(float64)])
-# def nanmean(a):
-#     asum = 0.0
-#     count = 0
-#     for ai in a.flat:
-#         if not np.isnan(ai):
-#             asum += ai
-#             count += 1
-#     if count > 0:
-#         return asum / count
-#     else:
-#         return np.nan
 
 
 @ndaggregate.wrap(
@@ -121,8 +76,8 @@ def nansum(a, out):
 def nanmean(a, out):
     asum = 0.0
     count = 0
-    for ai in a:
-        if ai == ai:
+    for ai in a.flat:
+        if not np.isnan(ai):
             asum += ai
             count += 1
     if count > 0:

--- a/numbagg/funcs.py
+++ b/numbagg/funcs.py
@@ -5,58 +5,130 @@ from numba import bool_, float32, float64, int32, int64
 
 from numbagg.decorators import ndaggregate, ndfill, ndquantile, ndreduce
 
+# @ndreduce.wrap([bool_(int32), bool_(int64), bool_(float32), bool_(float64)])
+# def allnan(a):
+#     f = True
+#     for ai in a.flat:
+#         if not np.isnan(ai):
+#             f = False
+#             break
+#     return f
 
-@ndreduce.wrap([bool_(int32), bool_(int64), bool_(float32), bool_(float64)])
-def allnan(a):
-    f = True
-    for ai in a.flat:
+@ndaggregate.wrap(
+    signature=[
+        (int32[:], bool_[:]),
+        (int64[:], bool_[:]),
+        (float32[:], bool_[:]),
+        (float64[:], bool_[:]),
+    ]
+)
+def allnan(a, out):
+    for ai in a:
         if not np.isnan(ai):
-            f = False
-            break
-    return f
+            out[0] = False
+            return
 
 
-@ndreduce.wrap([bool_(int32), bool_(int64), bool_(float32), bool_(float64)])
-def anynan(a):
-    f = False
-    for ai in a.flat:
+# @ndreduce.wrap([bool_(int32), bool_(int64), bool_(float32), bool_(float64)])
+# def anynan(a):
+#     f = False
+#     for ai in a.flat:
+#         if np.isnan(ai):
+#             f = True
+#             break
+#     return f
+
+@ndaggregate.wrap(
+    signature=[
+        (int32[:], bool_[:]),
+        (int64[:], bool_[:]),
+        (float32[:], bool_[:]),
+        (float64[:], bool_[:]),
+    ]
+)
+def anynan(a, out):
+    for ai in a:
         if np.isnan(ai):
-            f = True
-            break
-    return f
+            out[0] = True
+            return
 
+# @ndreduce.wrap([int64(int32), int64(int64), int64(float32), int64(float64)])
+# def nancount(a):
+#     non_missing = 0
+#     for ai in a.flat:
+#         if not np.isnan(ai):
+#             non_missing += 1
+#     return non_missing
 
-@ndreduce.wrap([int64(int32), int64(int64), int64(float32), int64(float64)])
-def nancount(a):
+@ndaggregate.wrap(
+    signature=[
+        (int32[:], int64[:]),
+        (int64[:], int64[:]),
+        (float32[:], int64[:]),
+        (float64[:], int64[:]),
+    ]
+)
+def nancount(a, out):
     non_missing = 0
-    for ai in a.flat:
+    for ai in a:
         if not np.isnan(ai):
             non_missing += 1
-    return non_missing
+    out[0] = non_missing
 
+# @ndreduce.wrap([int32(int32), int64(int64), float32(float32), float64(float64)])
+# def nansum(a):
+#     asum = 0
+#     for ai in a.flat:
+#         if not np.isnan(ai):
+#             asum += ai
+#     return asum
 
-@ndreduce.wrap([int32(int32), int64(int64), float32(float32), float64(float64)])
-def nansum(a):
-    asum = 0
-    for ai in a.flat:
-        if not np.isnan(ai):
+@ndaggregate.wrap(
+    signature=[
+        (int32[:], int32[:]),
+        (int64[:], int64[:]),
+        (float32[:], float32[:]),
+        (float64[:], float64[:]),
+    ]
+)
+def nansum(a, out):
+    asum = a.dtype.type(0)
+    for ai in a:
+        if ai == ai:
             asum += ai
-    return asum
+    out[0] = asum
+
+# @ndreduce.wrap([float32(float32), float64(float64)])
+# def nanmean(a):
+#     asum = 0.0
+#     count = 0
+#     for ai in a.flat:
+#         if not np.isnan(ai):
+#             asum += ai
+#             count += 1
+#     if count > 0:
+#         return asum / count
+#     else:
+#         return np.nan
 
 
-@ndreduce.wrap([float32(float32), float64(float64)])
-def nanmean(a):
+@ndaggregate.wrap(
+    signature=[
+        (float32[:], float32[:]),
+        (float64[:], float64[:]),
+    ]
+)
+def nanmean(a, out):
     asum = 0.0
     count = 0
-    for ai in a.flat:
-        if not np.isnan(ai):
+    for ai in a:
+        if ai == ai:
             asum += ai
             count += 1
     if count > 0:
-        return asum / count
+        out[0] = asum / count
     else:
-        return np.nan
-
+        out[0] = np.nan
 
 @ndaggregate.wrap(
     signature=[

--- a/numbagg/test/test_funcs.py
+++ b/numbagg/test/test_funcs.py
@@ -25,9 +25,8 @@ from numbagg import (
     nanvar,
 )
 from numbagg.moving_exp import move_exp_nanmean
+from numbagg.test.conftest import COMPARISONS
 from numbagg.test.util import arrays
-
-from .conftest import COMPARISONS
 
 
 @pytest.mark.parametrize(

--- a/numbagg/test/test_moving.py
+++ b/numbagg/test/test_moving.py
@@ -71,7 +71,6 @@ def test_numerical_results_identical(func, func0):
     else:
         decimal = 5
     for i, a in enumerate(arrays(func_name)):
-
         if a.size >= 1_000:
             print(f"{func_name}: skipping large array with shape {a.shape}")
             continue

--- a/numbagg/test/test_moving.py
+++ b/numbagg/test/test_moving.py
@@ -71,6 +71,10 @@ def test_numerical_results_identical(func, func0):
     else:
         decimal = 5
     for i, a in enumerate(arrays(func_name)):
+
+        if a.size >= 1_000:
+            print(f"{func_name}: skipping large array with shape {a.shape}")
+            continue
         axes = range(-1, a.ndim)
         for axis in axes:
             windows = range(1, a.shape[axis])

--- a/numbagg/test/util.py
+++ b/numbagg/test/util.py
@@ -83,6 +83,13 @@ def array_generator(func_name, dtypes):
     ss[2] = {"size": 12, "shapes": [(2, 6), (3, 4)]}
     ss[3] = {"size": 16, "shapes": [(2, 2, 4)]}
     ss[4] = {"size": 24, "shapes": [(1, 2, 3, 4)]}
+
+    # some large arrays to ensure numerical precision
+    ss[5] = {"size": 1_000, "shapes": [(1_000,)]}
+    ss[6] = {"size": 10_000, "shapes": [(100, 100)]}
+    ss[7] = {"size": 1_000_000, "shapes": [(1_000, 1_000)]}
+    ss[8] = {"size": 1_000_000, "shapes": [(100, 10_000)]}
+
     for seed in (1, 2):
         rs = np.random.RandomState(seed)
         for ndim in ss:


### PR DESCRIPTION
With this PR `fastmath` optimizations can be optionally enabled via a `NUMBAGG_FASTMATH` environment variable. A warning is always issued when used. Importantly, we don't simply use `fastmath=True` but specify a set of [flags](https://llvm.org/docs/LangRef.html#fast-math-flags) that should not result in unsafe behavior, but possibly in reduced precision. The "no nans" and "no infs" fastmath flags are __not__ used. See also the discussion in #287. 
In my benchmarks I only observe a 2x performance improvement on `nansum` and `nanmean` (for double precision floats, in micro-benchmarks I saw 4x for single precision), smaller performance improvements on `nanstd` and `nanvar`, and no noticeable differences, or even slightly worse results, on all other aggregations.
Closes #287 

## Tests
Tests are passing, including those for correctness, when `NUMBAGG_FASTMATH=true`, which should indicate it's safe to use it. This also includes tests for large arrays (1'000'000 elements).

## Benchmark: Linux system with 8 skylake-avx512 CPUs

#### `NUMBAGG_FASTMATH=true`:

| func                      |   1D<br>pandas |   1D<br>bottleneck |   1D<br>numpy |   2D<br>pandas |   2D<br>bottleneck |   2D<br>numpy |
|:--------------------------|---------------:|-------------------:|--------------:|---------------:|-------------------:|--------------:|
| `bfill`                   |          1.80x |              1.17x |           n/a |         21.54x |              7.70x |           n/a |
| `ffill`                   |          2.12x |              1.59x |           n/a |         25.84x |              9.85x |           n/a |
| `group_nanall`            |          1.49x |                n/a |           n/a |         12.51x |                n/a |           n/a |
| `group_nanany`            |          1.43x |                n/a |           n/a |         13.05x |                n/a |           n/a |
| `group_nanargmax`         |          1.28x |                n/a |           n/a |         10.04x |                n/a |           n/a |
| `group_nanargmin`         |          1.22x |                n/a |           n/a |          9.61x |                n/a |           n/a |
| `group_nancount`          |          1.26x |                n/a |           n/a |          8.21x |                n/a |           n/a |
| `group_nanfirst`          |          1.34x |                n/a |           n/a |         19.43x |                n/a |           n/a |
| `group_nanlast`           |          1.20x |                n/a |           n/a |          8.27x |                n/a |           n/a |
| `group_nanmax`            |          1.21x |                n/a |           n/a |          8.14x |                n/a |           n/a |
| `group_nanmean`           |          1.38x |                n/a |           n/a |         13.98x |                n/a |           n/a |
| `group_nanmin`            |          1.27x |                n/a |           n/a |          8.08x |                n/a |           n/a |
| `group_nanprod`           |          1.21x |                n/a |           n/a |          7.62x |                n/a |           n/a |
| `group_nanstd`            |          1.35x |                n/a |           n/a |         12.17x |                n/a |           n/a |
| `group_nansum_of_squares` |          1.65x |                n/a |           n/a |         21.51x |                n/a |           n/a |
| `group_nansum`            |          1.41x |                n/a |           n/a |         13.73x |                n/a |           n/a |
| `group_nanvar`            |          1.36x |                n/a |           n/a |         13.44x |                n/a |           n/a |
| `move_corr`               |         28.32x |                n/a |           n/a |        148.17x |                n/a |           n/a |
| `move_cov`                |         23.53x |                n/a |           n/a |        121.59x |                n/a |           n/a |
| `move_exp_nancorr`        |         12.59x |                n/a |           n/a |         78.87x |                n/a |           n/a |
| `move_exp_nancount`       |          3.98x |                n/a |           n/a |         20.27x |                n/a |           n/a |
| `move_exp_nancov`         |         11.46x |                n/a |           n/a |         78.58x |                n/a |           n/a |
| `move_exp_nanmean`        |          3.61x |                n/a |           n/a |         23.49x |                n/a |           n/a |
| `move_exp_nanstd`         |          2.71x |                n/a |           n/a |         21.07x |                n/a |           n/a |
| `move_exp_nansum`         |          3.23x |                n/a |           n/a |         21.76x |                n/a |           n/a |
| `move_exp_nanvar`         |          2.99x |                n/a |           n/a |         20.68x |                n/a |           n/a |
| `move_mean`               |          5.42x |              0.89x |           n/a |         28.66x |              5.97x |           n/a |
| `move_std`                |          6.39x |              0.94x |           n/a |         36.55x |              6.95x |           n/a |
| `move_sum`                |          5.17x |              0.87x |           n/a |         27.45x |              6.04x |           n/a |
| `move_var`                |          5.97x |              1.01x |           n/a |         34.26x |              7.14x |           n/a |
| `nanargmax`[^5]           |          6.92x |              0.91x |           n/a |          5.27x |              0.91x |           n/a |
| `nanargmin`[^5]           |          7.01x |              0.90x |           n/a |          5.67x |              0.92x |           n/a |
| `nancount`                |          1.84x |                n/a |         1.61x |         22.48x |                n/a |        13.43x |
| `nanmax`[^5]              |          0.66x |              0.64x |         0.31x |          1.10x |              0.69x |         0.33x |
| `nanmean`                 |          8.23x |              2.17x |         9.52x |         77.79x |             17.48x |        79.58x |
| `nanmin`[^5]              |          0.66x |              0.68x |         0.30x |          1.00x |              0.64x |         0.30x |
| `nanquantile`             |          0.75x |                n/a |         0.61x |          4.99x |                n/a |         4.83x |
| `nanstd`                  |          1.55x |              1.47x |         5.47x |         13.99x |             10.81x |        44.85x |
| `nansum`                  |          7.40x |              1.95x |         8.32x |         80.83x |             18.30x |        73.13x |
| `nanvar`                  |          1.53x |              1.39x |         5.33x |         12.86x |             10.35x |        41.29x |


#### `NUMBAGG_FASTMATH=false`:


| func                      |   1D<br>pandas |   1D<br>bottleneck |   1D<br>numpy |   2D<br>pandas |   2D<br>bottleneck |   2D<br>numpy |
|:--------------------------|---------------:|-------------------:|--------------:|---------------:|-------------------:|--------------:|
| `bfill`                   |          1.72x |              1.18x |           n/a |         21.78x |              7.71x |           n/a |
| `ffill`                   |          2.13x |              1.57x |           n/a |         27.47x |              9.52x |           n/a |
| `group_nanall`            |          1.42x |                n/a |           n/a |         12.80x |                n/a |           n/a |
| `group_nanany`            |          1.43x |                n/a |           n/a |         12.96x |                n/a |           n/a |
| `group_nanargmax`         |          1.34x |                n/a |           n/a |         10.83x |                n/a |           n/a |
| `group_nanargmin`         |          1.23x |                n/a |           n/a |         10.53x |                n/a |           n/a |
| `group_nancount`          |          1.25x |                n/a |           n/a |          8.06x |                n/a |           n/a |
| `group_nanfirst`          |          1.37x |                n/a |           n/a |         21.19x |                n/a |           n/a |
| `group_nanlast`           |          1.26x |                n/a |           n/a |          9.57x |                n/a |           n/a |
| `group_nanmax`            |          1.25x |                n/a |           n/a |          8.83x |                n/a |           n/a |
| `group_nanmean`           |          1.38x |                n/a |           n/a |         15.23x |                n/a |           n/a |
| `group_nanmin`            |          1.24x |                n/a |           n/a |          8.90x |                n/a |           n/a |
| `group_nanprod`           |          1.30x |                n/a |           n/a |          8.98x |                n/a |           n/a |
| `group_nanstd`            |          1.36x |                n/a |           n/a |         13.15x |                n/a |           n/a |
| `group_nansum_of_squares` |          1.57x |                n/a |           n/a |         21.60x |                n/a |           n/a |
| `group_nansum`            |          1.35x |                n/a |           n/a |         15.07x |                n/a |           n/a |
| `group_nanvar`            |          1.39x |                n/a |           n/a |         12.77x |                n/a |           n/a |
| `move_corr`               |         24.69x |                n/a |           n/a |        138.69x |                n/a |           n/a |
| `move_cov`                |         22.53x |                n/a |           n/a |        129.15x |                n/a |           n/a |
| `move_exp_nancorr`        |         11.09x |                n/a |           n/a |         75.82x |                n/a |           n/a |
| `move_exp_nancount`       |          3.95x |                n/a |           n/a |         21.67x |                n/a |           n/a |
| `move_exp_nancov`         |         10.25x |                n/a |           n/a |         78.33x |                n/a |           n/a |
| `move_exp_nanmean`        |          2.93x |                n/a |           n/a |         23.15x |                n/a |           n/a |
| `move_exp_nanstd`         |          2.62x |                n/a |           n/a |         19.62x |                n/a |           n/a |
| `move_exp_nansum`         |          3.14x |                n/a |           n/a |         23.23x |                n/a |           n/a |
| `move_exp_nanvar`         |          2.75x |                n/a |           n/a |         21.07x |                n/a |           n/a |
| `move_mean`               |          5.56x |              0.94x |           n/a |         31.32x |              6.43x |           n/a |
| `move_std`                |          6.70x |              0.94x |           n/a |         37.33x |              6.85x |           n/a |
| `move_sum`                |          5.14x |              0.92x |           n/a |         28.64x |              6.39x |           n/a |
| `move_var`                |          5.94x |              1.00x |           n/a |         36.89x |              7.15x |           n/a |
| `nanargmax`[^5]           |          6.12x |              0.90x |           n/a |          5.42x |              0.86x |           n/a |
| `nanargmin`[^5]           |          6.85x |              0.77x |           n/a |          5.55x |              0.77x |           n/a |
| `nancount`                |          1.88x |                n/a |         1.48x |         23.93x |                n/a |        12.99x |
| `nanmax`[^5]              |          0.71x |              0.72x |         0.32x |          1.01x |              0.68x |         0.30x |
| `nanmean`                 |          4.76x |              1.29x |         5.49x |         36.56x |              8.55x |        39.01x |
| `nanmin`[^5]              |          0.71x |              0.70x |         0.32x |          1.07x |              0.70x |         0.32x |
| `nanquantile`             |          0.76x |                n/a |         0.63x |          5.40x |                n/a |         5.55x |
| `nanstd`                  |          1.31x |              1.31x |         4.82x |         10.66x |              8.99x |        35.21x |
| `nansum`                  |          4.88x |              1.40x |         5.49x |         38.33x |              8.25x |        34.83x |
| `nanvar`                  |          1.40x |              1.38x |         4.73x |         10.77x |              9.56x |        33.81x |
    
