### PR TITLE
Allow the compilation cost benchmarks to succeed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,6 +80,41 @@ jobs:
         run: |
           micromamba run -n numbagg-tests python numbagg/test/run_benchmarks.py
 
+  nightly:
+    # Only run on merges to main (could also add a schedule or something similar)
+    # All is copied from above apart from the `--run-nightly` & `--benchmark-enable` flags
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup micromamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: numbagg-tests
+          cache-environment: true
+          cache-environment-key: "${{matrix.os}}-${{matrix.python-version}}"
+          create-args: >-
+            python=${{matrix.python-version}} numba pandas bottleneck pytest pytest-benchmark hypothesis tabulate pyarrow
+
+      - name: Install numbagg
+        run: |
+          python -m pip install -e .[dev]
+
+      - name: Run benchmarks
+        run: |
+          python -m pytest --durations=20 -W error --run-nightly --benchmark-enable
+
   mypy:
     runs-on: ubuntu-latest
     defaults:

--- a/numbagg/test/test_benchmark.py
+++ b/numbagg/test/test_benchmark.py
@@ -58,7 +58,11 @@ def test_benchmark_f_bfill(benchmark, func_callable):
 
 @pytest.fixture
 def clear_numba_cache(func):
-    func.gufunc.cache_clear()
+    if hasattr(func, "gufunc"):
+        func.gufunc.cache_clear()
+    else:
+        # Functions like `nanmedian` are wrappers, so we can't clear a cache
+        pytest.skip(f"Can't clear cache for {func}")
 
     yield
 


### PR DESCRIPTION
Currently one function fails, and we weren't testing this in CI
