### PR TITLE
Add tests for segfaulting with parallel + cache

### DIFF
--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -39,6 +39,18 @@ if os.getenv("NUMBAGG_FASTMATH", "False").lower() in ("true", "1", "t"):
 else:
     _FASTMATH = False  # type: ignore[assignment]
 
+# https://github.com/numba/numba/issues/4807
+if os.getenv("NUMBAGG_CACHE", "False").lower() in ("true", "1", "t"):
+    _ENABLE_CACHE = True
+    warnings.warn(
+        "Numba caching is enabled in numbagg. "
+        "This will likely cause segfaults when used with multiprocessing. "
+        "See https://github.com/numba/numba/issues/4807",
+        UserWarning,
+    )
+else:
+    _ENABLE_CACHE = False
+
 
 def _gufunc_arg_str(arg):
     return f"({','.join(_ALPHABET[: ndim(arg)])})"
@@ -71,8 +83,8 @@ class NumbaBase:
 
     def __init__(self, func: Callable, supports_parallel: bool = True):
         self.func = func
-        # https://github.com/numba/numba/issues/4807
-        self.cache = False
+
+        self.cache = _ENABLE_CACHE
         self.supports_parallel = supports_parallel
         self._target_cpu = not supports_parallel
         functools.wraps(func)(self)

--- a/numbagg/test/test_cache_segfault.py
+++ b/numbagg/test/test_cache_segfault.py
@@ -1,0 +1,156 @@
+import importlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+from textwrap import dedent
+
+import numpy as np
+import pytest
+
+from numbagg.grouped import group_nanmean
+
+pytestmark = pytest.mark.nightly
+
+
+@pytest.fixture()
+def clean_pycache():
+    """Clean all __pycache__ directories, seems to be necessary to get a segfault repro"""
+    # Clean before test
+    for pycache in Path().rglob("__pycache__"):
+        shutil.rmtree(pycache)
+
+    yield
+
+    # Clean after test
+    for pycache in Path().rglob("__pycache__"):
+        shutil.rmtree(pycache)
+
+
+def f_numba(i, x):
+    """Import and run a numba function from generated module"""
+    mod = importlib.import_module(f"numba_segfault._{i:04d}")
+    return mod.f(x)
+
+
+@pytest.mark.xfail(
+    reason="Known segfault issue with numba caching in multiprocessing - https://github.com/numba/numba/issues/4807"
+)
+def test_numba_cache_segfault():
+    """Test that reproduces numba cache segfault with multiple processes
+
+    From https://github.com/numba/numba/issues/4807#issuecomment-551167331
+    """
+
+    jobs = 32
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pkg_dir = Path(tmpdir) / "numba_segfault"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").touch()
+
+        # Create all the test modules up front
+        for i in range(1600):
+            with open(pkg_dir / f"_{i:04d}.py", "w") as fh:
+                fh.write(
+                    dedent(
+                        """
+                        from numba import guvectorize, f8
+
+                        @guvectorize([(f8, f8[:])], "()->()", nopython=True, cache=True)
+                        def f(x, out):
+                            out[0] = x * 2
+                        """
+                    ).lstrip()
+                )
+
+        # Add package dir to Python path so we can import our generated modules
+        sys.path.insert(0, str(tmpdir))
+        with ProcessPoolExecutor(jobs) as pool:
+            futures = []
+            for i in range(1600):
+                futures.extend([pool.submit(f_numba, i, x) for x in range(jobs)])
+
+            for i, future in enumerate(futures):
+                future.result()
+                if i % 100 == 0:
+                    print(f"Completed {i} numba tasks")
+
+
+def numbagg_worker(i, x):
+    """Worker function that creates similar work to the numba test"""
+    arr = np.full(1, x)
+    labels = np.zeros(1, dtype=np.int64)
+    return group_nanmean(arr, labels)
+
+
+@pytest.mark.xfail(
+    reason="Known segfault issue with numba caching in multiprocessing - https://github.com/numba/numba/issues/4807"
+)
+def test_numbagg_cache_segfault(clean_pycache):
+    """Test that reproduces numba cache segfault with numbagg's group_nanmean — doesn't
+    seem to currently fail though"""
+    jobs = 32
+
+    with ProcessPoolExecutor(jobs) as pool:
+        futures = []
+        for i in range(1600):
+            futures.extend([pool.submit(numbagg_worker, i, x) for x in range(jobs)])
+
+        for i, future in enumerate(futures):
+            future.result()
+            if i % 100 == 0:
+                print(f"Completed {i} numbagg tasks")
+
+
+def test_numbagg_module_cache_segfault(clean_pycache):
+    """
+    Test that sets the cache to be true, and more closely reproduces the numba cache
+    segfault repro with numbagg functions in separate modules, since I was having issues
+    reproducing the segfault with the simpler `test_numbagg_cache_segfault` test"""
+
+    # Create a temporary script that runs our test
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(
+            dedent(
+                """
+            import numpy as np
+            from concurrent.futures import ProcessPoolExecutor
+            from numbagg.grouped import group_nanmean
+
+            def worker(i, x):
+                arr = np.full(1, x)
+                labels = np.zeros(1, dtype=np.int64)
+                return group_nanmean(arr, labels)
+
+            def main():
+                jobs = 32
+                with ProcessPoolExecutor(jobs) as pool:
+                    futures = []
+                    for i in range(100):
+                        futures.extend([pool.submit(worker, i, x) for x in range(jobs)])
+
+                    for future in futures:
+                        future.result()
+
+            if __name__ == "__main__":
+                main()
+        """
+            )
+        )
+        f.flush()
+
+        env = os.environ.copy()
+        env["NUMBAGG_CACHE"] = "True"
+        env["PYTHONPATH"] = str(Path(__file__).parent.parent.parent)  # project root
+
+        # Run the script and expect it to fail
+        process = subprocess.run(
+            [sys.executable, f.name], env=env, capture_output=True, text=True
+        )
+
+        # Process should have failed with a segfault and show warning about caching
+        assert "will likely cause segfaults" in process.stderr
+        assert process.returncode != 0, "Process should have failed with segfault"

--- a/numbagg/test/test_cache_segfault.py
+++ b/numbagg/test/test_cache_segfault.py
@@ -91,7 +91,7 @@ def numbagg_worker(i, x):
 )
 def test_numbagg_cache_segfault(clean_pycache):
     """Test that reproduces numba cache segfault with numbagg's group_nanmean — doesn't
-    seem to currently fail though"""
+    seem to currently fail though, even when `_NUMBAGG_CACHE` is set to `True`"""
     jobs = 32
 
     with ProcessPoolExecutor(jobs) as pool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools", "wheel", "setuptools_scm"]
 
 [project]
 authors = [
-  {name = "Stephan Hoyer", email = "shoyer@gmail.com"},
-  {name = "Maximilian Roos", email = "m@maxroos.com"},
+  { name = "Stephan Hoyer", email = "shoyer@gmail.com" },
+  { name = "Maximilian Roos", email = "m@maxroos.com" },
 ]
 classifiers = [
   # "License :: OSI Approved :: BSD License",
@@ -23,7 +23,7 @@ dependencies = ["numpy", "numba"]
 
 description = "Fast N-dimensional aggregation functions with Numba"
 dynamic = ["version"]
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 name = "numbagg"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -58,18 +58,20 @@ target-version = "py39"
 # E402: module level import not at top of file
 # E501: line too long - let black worry about that
 # E731: do not assign a lambda expression, use a def
-ignore = [
-  "E402",
-  "E501",
-  "E731",
-]
+ignore = ["E402", "E501", "E731"]
 select = [
-  "F", # Pyflakes
-  "E", # Pycodestyle
+  "F",  # Pyflakes
+  "E",  # Pycodestyle
   "W",
-  "I", # isort
+  "I",  # isort
   "UP", # Pyupgrade
 ]
+
+[tool.ruff.lint.isort]
+known-first-party = ["numbagg"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
 
 [tool.mypy]
 check_untyped_defs = true


### PR DESCRIPTION
In pursuit of https://github.com/numbagg/numbagg/issues/345, this adds some tests for whether we get segfaults.

It wasn't trivial to get working reproductions, and they depend on some delicate conditions, such as when the `__pycache__` paths were generated. Probably we can make the tests a bit smaller, but they do appear to work.

Unfortunately adding `_reload_parfors` doesn't seem to help; possibly because it's in the wrong place. I'll follow up with a PR with my current best attempt
