### PR TITLE
Try `parfor` workaround

### DIFF
--- a/numbagg/__init__.py
+++ b/numbagg/__init__.py
@@ -1,5 +1,10 @@
 from importlib.metadata import version as _version
 
+from numba.core.typed_passes import _reload_parfors
+
+# https://github.com/numba/numba/issues/8578
+_reload_parfors()
+
 from .funcs import (
     allnan,
     anynan,

--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -84,6 +84,12 @@ class NumbaBase:
     def __init__(self, func: Callable, supports_parallel: bool = True):
         self.func = func
 
+        from numba.core.typed_passes import _reload_parfors
+
+        # https://github.com/numba/numba/issues/4807
+        _reload_parfors()
+        self.cache = _ENABLE_CACHE
+
         self.cache = _ENABLE_CACHE
         self.supports_parallel = supports_parallel
         self._target_cpu = not supports_parallel
@@ -471,6 +477,9 @@ class groupndreduce(NumbaBase):
         num_labels: int | None = None,
         axis: int | tuple[int, ...] | None = None,
     ):
+        from numba.core.typed_passes import _reload_parfors
+
+        _reload_parfors()
         values = np.asarray(values)
         labels = np.asarray(labels)
 


### PR DESCRIPTION
Unfortunately this doesn't work: the test that asserts that a segfault occurs still "passes". I spammed the function everywhere to ensure that wasn't the problem (unless there's somewhere I missed? I'm assuming it's not _inside_ the function).

Ref https://github.com/numbagg/numbagg/issues/345 & https://github.com/numba/numba/issues/4807 & https://github.com/numba/numba/issues/8578
