### PR TITLE
Cut grouped functions' compile time by 40%

### DIFF
--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -397,7 +397,7 @@ class groupndreduce(NumbaBase):
 
         if signature is None:
             values_dtypes: tuple[numba.dtype, ...] = (numba.float32, numba.float64)
-            labels_dtypes = (numba.int8, numba.int16, numba.int32, numba.int64)
+            labels_dtypes = (numba.int32, numba.int64)
             if supports_ints:
                 values_dtypes += (numba.int32, numba.int64)
 

--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -397,6 +397,9 @@ class groupndreduce(NumbaBase):
 
         if signature is None:
             values_dtypes: tuple[numba.dtype, ...] = (numba.float32, numba.float64)
+            # We restrict to int32 & int64 to reduce compile time. When numba supports
+            # dynamic compilation, we'll accept everything. We cast up to int32 if the
+            # type is smaller than that.
             labels_dtypes = (numba.int32, numba.int64)
             if supports_ints:
                 values_dtypes += (numba.int32, numba.int64)
@@ -491,6 +494,9 @@ class groupndreduce(NumbaBase):
                 f"Arguments had {values.ndim} & {labels.ndim} dimensions. "
                 "Please raise an issue if this feature would be particularly helpful."
             )
+
+        if labels.dtype.kind == "i" and labels.dtype < np.dtype("int16"):
+            labels = labels.astype(np.int32)
 
         # We need to be careful that we don't overflow `counts` in the grouping
         # function. So the labels need to be a big enough integer type to hold the


### PR DESCRIPTION
...by halving the number of dtypes we accept for labels. This means we need to do a copy where labels are `int8` or `int16`, but I think that's rare enough that it's a reasonable tradeoff

Contributes towards #345
