### PR TITLE
Update typos pre-commit hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,10 @@ repos:
   #    - id: mypy
   #      additional_dependencies:
   #        [types-setuptools, numpy, types-Pygments, types-colorama]
-  - repo: https://github.com/crate-ci/typos
-    rev: v1
+  - repo: https://github.com/adhtruong/mirrors-typos
+    rev: v1.27.3
     hooks:
       - id: typos
-        # https://github.com/crate-ci/typos/issues/347
-        pass_filenames: false
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:


### PR DESCRIPTION
Change typos repository to a mirror and update its version.
Remove `pass_filenames: false` as it is no longer needed.

Co-authored-by: Claude <no-reply@anthropic.com>
