### PR TITLE
Avoid special-casing diagonals in matrix calcs

### DIFF
--- a/numbagg/funcs.py
+++ b/numbagg/funcs.py
@@ -336,17 +336,6 @@ def nancorrmatrix(a, out):
     # Compute correlation matrix
     for i in range(n_vars):
         for j in range(i, n_vars):  # Only compute upper triangle
-            if i == j:
-                # Diagonal: correlation with itself is 1.0 if any valid values exist
-                for k in range(n_obs):
-                    if not np.isnan(a[i, k]):
-                        out[i, j] = 1.0
-                        break
-                else:
-                    # No valid values found
-                    out[i, j] = np.nan
-                continue
-
             # Find pairwise complete observations and compute sums in one pass
             sum_i = 0.0
             sum_j = 0.0

--- a/numbagg/test/test_move_exp_matrix_advanced.py
+++ b/numbagg/test/test_move_exp_matrix_advanced.py
@@ -43,9 +43,9 @@ class TestMoveExpMatrixAdvanced:
                 # 2. Matrix should be symmetric
                 assert_allclose(corr_matrix, corr_matrix.T, rtol=1e-12)
 
-                # 3. All values should be in [-1, 1]
-                assert np.all(corr_matrix >= -1.0)
-                assert np.all(corr_matrix <= 1.0)
+                # 3. All values should be very close to [-1, 1] (allowing for floating-point precision)
+                assert np.all(corr_matrix >= -1.0 - 1e-10)
+                assert np.all(corr_matrix <= 1.0 + 1e-10)
 
                 # 4. Should be positive semi-definite
                 eigenvals = np.linalg.eigvals(corr_matrix)
@@ -94,8 +94,9 @@ class TestMoveExpMatrixAdvanced:
         assert_allclose(final_cov[0, 1], 0.0, atol=1e-10)
         assert_allclose(final_cov[1, 0], 0.0, atol=1e-10)
 
-        # Correlation diagonal should be 1.0
-        assert_allclose(np.diag(final_corr), [1.0, 1.0], rtol=1e-10)
+        # Correlation diagonal should be NaN for constant data (zero variance)
+        assert np.isnan(final_corr[0, 0])
+        assert np.isnan(final_corr[1, 1])
 
         # Off-diagonal correlation should be NaN (0/0 case)
         assert np.isnan(final_corr[0, 1])


### PR DESCRIPTION
This change modifies `nancorrmatrix`, `move_nancorrmatrix`, and `move_exp_nancorrmatrix` to correctly return `NaN` for correlation values when the variance of a series is zero. Previously, the diagonal elements were explicitly set to 1.0, which is incorrect for constant data.

Additionally, the test for correlation matrix properties was updated to allow for small floating-point deviations from -1.0 and 1.0, and the test for constant time series now correctly asserts `NaN` for diagonal correlation values.

Co-authored-by: Claude <no-reply@anthropic.com>
