### PR TITLE
Add exponential moving matrix functions to benchmarks

### DIFF
--- a/numbagg/test/conftest.py
+++ b/numbagg/test/conftest.py
@@ -37,8 +37,10 @@ from .. import (
     move_covmatrix,
     # move_count,
     move_exp_nancorr,
+    move_exp_nancorrmatrix,
     move_exp_nancount,
     move_exp_nancov,
+    move_exp_nancovmatrix,
     move_exp_nanmean,
     move_exp_nanstd,
     move_exp_nansum,
@@ -123,8 +125,13 @@ def pandas_static_covmatrix(a):
 
 
 def pandas_rolling_matrix_setup(a, window=20, min_count=None):
-    """Setup rolling window for matrix operations (corr/cov)."""
-    df = pandas_matrix_setup(a)
+    """Setup rolling window for matrix operations (corr/cov).
+
+    For rolling functions, expect (..., obs, vars) format.
+    Observations as rows (time series), variables as columns.
+    """
+    # For rolling: DON'T transpose - we want (obs, vars) as (rows, cols)
+    df = pd.DataFrame(a)
     rolling = df.rolling(window, min_periods=min_count)
     return rolling
 
@@ -194,6 +201,16 @@ def pandas_nan_sum_of_squares_setup(a):
     labels = generate_labels(a.shape[-1])
     df = _df_of_array(a)
     return lambda: df.pipe(lambda x: x**2).groupby(labels).sum().T
+
+
+def _transform_for_matrix_function(a):
+    """Transform array for STATIC matrix functions expecting (..., vars, obs) convention.
+
+    Input convention (from benchmark): (..., obs, vars) - batch dims at front
+    Output convention (for static funcs): (..., vars, obs) - swap last two dimensions
+    Moving functions use input as-is since they expect (..., obs, vars).
+    """
+    return a.swapaxes(-2, -1)
 
 
 def _df_of_array(a):
@@ -482,24 +499,24 @@ COMPARISONS: dict[Callable, dict[str, Callable]] = {
     # ),
     nancorrmatrix: dict(
         numbagg=lambda a, axis=-1: partial(
-            nancorrmatrix, a
-        ),  # No axis parameter, uses fixed (vars, obs) convention
+            nancorrmatrix, _transform_for_matrix_function(a)
+        ),  # Static functions need (vars, obs) convention
         pandas=pandas_static_corrmatrix,
-        numpy=lambda a: lambda: np.corrcoef(a),
+        # Note: np.corrcoef doesn't handle NaNs (returns all NaN), so no numpy comparison
     ),
     nancovmatrix: dict(
         numbagg=lambda a, axis=-1: partial(
-            nancovmatrix, a
-        ),  # No axis parameter, uses fixed (vars, obs) convention
+            nancovmatrix, _transform_for_matrix_function(a)
+        ),  # Static functions need (vars, obs) convention
         pandas=pandas_static_covmatrix,
-        numpy=lambda a: lambda: np.cov(a),
+        # Note: np.cov doesn't handle NaNs (returns all NaN), so no numpy comparison
     ),
     move_corrmatrix: dict(
         numbagg=lambda a, window=20, **kwargs: partial(
             move_corrmatrix,
-            a.T,
+            a,
             window=window,
-            **kwargs,  # Transpose for new (obs, vars) convention
+            **kwargs,
         ),
         pandas=lambda a, window=20, **kwargs: pandas_rolling_corrmatrix(
             a, window=window, min_count=kwargs.get("min_count", None)
@@ -508,12 +525,28 @@ COMPARISONS: dict[Callable, dict[str, Callable]] = {
     move_covmatrix: dict(
         numbagg=lambda a, window=20, **kwargs: partial(
             move_covmatrix,
-            a.T,
+            a,
             window=window,
-            **kwargs,  # Transpose for new (obs, vars) convention
+            **kwargs,
         ),
         pandas=lambda a, window=20, **kwargs: pandas_rolling_covmatrix(
             a, window=window, min_count=kwargs.get("min_count", None)
+        ),
+    ),
+    move_exp_nancorrmatrix: dict(
+        numbagg=lambda a, alpha=0.5, **kwargs: partial(
+            move_exp_nancorrmatrix,
+            a,
+            alpha=alpha,
+            **kwargs,
+        ),
+    ),
+    move_exp_nancovmatrix: dict(
+        numbagg=lambda a, alpha=0.5, **kwargs: partial(
+            move_exp_nancovmatrix,
+            a,
+            alpha=alpha,
+            **kwargs,
         ),
     ),
 }
@@ -575,6 +608,8 @@ def func_callable(library, func, array):
         "nancovmatrix",
         "move_corrmatrix",
         "move_covmatrix",
+        "move_exp_nancorrmatrix",
+        "move_exp_nancovmatrix",
     ]:
         # Matrix functions need 2D input
         if array.ndim == 1:
@@ -585,15 +620,18 @@ def func_callable(library, func, array):
                 pytest.skip(
                     "numpy's corrcoef/cov doesn't support >2D arrays (but numbagg does!)"
                 )
-            if library == "pandas" and array.size >= 100000:
+            if library == "pandas" and array.size >= 10_000_000:
                 pytest.skip(
-                    f"pandas would create too large matrix ({array.size}x{array.size})"
+                    f"pandas matrix operation on large array (size={array.size}) may be too slow"
                 )
         else:  # move_ functions
             if library == "numpy":
                 pytest.skip("numpy doesn't have rolling matrix functions")
             if library == "bottleneck":
                 pytest.skip("bottleneck doesn't have rolling matrix functions")
+            # For exponential matrix functions, only numbagg is supported
+            if func.__name__.startswith("move_exp_") and library == "pandas":
+                pytest.skip("pandas doesn't have exponential moving matrix functions")
 
     try:
         callable_ = COMPARISONS[func][library](array)

--- a/numbagg/test/test_benchmark.py
+++ b/numbagg/test/test_benchmark.py
@@ -113,7 +113,7 @@ def test_benchmark_f_bfill(benchmark, func_callable):
         pytest.param((5, 100000), marks=pytest.mark.slow),  # 5×5 matrix, target ~10ms
         pytest.param((50, 500), marks=pytest.mark.slow),  # 50×50 matrix, target >2ms
         pytest.param(
-            (3000, 1000, 5), marks=pytest.mark.slow
+            (3000, 5, 1000), marks=pytest.mark.slow
         ),  # 3000 independent 5×5 matrices, 1000 obs each, target ~50ms
     ],
     indirect=True,

--- a/numbagg/test/test_moving.py
+++ b/numbagg/test/test_moving.py
@@ -54,7 +54,9 @@ def test_move_pandas_comp(array, func, window, min_count):
 
 
 @pytest.mark.parametrize("func", [move_corrmatrix, move_covmatrix], indirect=True)
-@pytest.mark.parametrize("shape", [(100, 5)], indirect=True)
+@pytest.mark.parametrize(
+    "shape", [(5, 100)], indirect=True
+)  # (vars, obs) benchmark convention
 @pytest.mark.parametrize("window", [10, 30])
 @pytest.mark.parametrize("min_count", [None, "window"])
 def test_move_matrix_pandas_comp(array, func, window, min_count):
@@ -75,8 +77,9 @@ def test_move_matrix_pandas_comp(array, func, window, min_count):
     pandas_result = pandas_callable()
 
     # Convert pandas MultiIndex DataFrame to 3D array for comparison
-    n_obs = array.shape[-2]  # obs is second-to-last dimension now
-    n_vars = array.shape[-1]  # vars is last dimension now
+    # Result shape is (..., obs, vars, vars), so we can infer dimensions from result
+    n_obs = result.shape[-3]  # obs dimension
+    n_vars = result.shape[-2]  # vars dimension (should equal result.shape[-1])
     expected_pandas = np.full((n_obs, n_vars, n_vars), np.nan)
 
     # Only include windows where we have at least min_count observations
@@ -98,9 +101,9 @@ def test_move_matrix_pandas_comp(array, func, window, min_count):
 @pytest.mark.parametrize("min_count", [1, 2, 3, 4, 5])
 def test_move_matrix_pandas_min_count_simple(func_name, window, min_count):
     """Test matrix functions against pandas with different min_count values."""
-    # Create test array directly
+    # Create test array directly in benchmark format (vars, obs)
     rs = np.random.RandomState(0)
-    array = rs.rand(15, 4)
+    array = rs.rand(4, 15)  # (vars=4, obs=15)
 
     # Get the function
     func = move_corrmatrix if func_name == "move_corrmatrix" else move_covmatrix
@@ -116,8 +119,9 @@ def test_move_matrix_pandas_min_count_simple(func_name, window, min_count):
     pandas_result = pandas_callable()
 
     # Convert pandas MultiIndex DataFrame to 3D array
-    n_obs = array.shape[-2]  # obs is second-to-last dimension now
-    n_vars = array.shape[-1]  # vars is last dimension now
+    # Result shape is (..., obs, vars, vars), so we can infer dimensions from result
+    n_obs = result.shape[-3]  # obs dimension
+    n_vars = result.shape[-2]  # vars dimension (should equal result.shape[-1])
     expected_pandas = np.full((n_obs, n_vars, n_vars), np.nan)
 
     for t in range(n_obs):

--- a/numbagg/test/test_moving.py
+++ b/numbagg/test/test_moving.py
@@ -54,7 +54,7 @@ def test_move_pandas_comp(array, func, window, min_count):
 
 
 @pytest.mark.parametrize("func", [move_corrmatrix, move_covmatrix], indirect=True)
-@pytest.mark.parametrize("shape", [(5, 100)], indirect=True)
+@pytest.mark.parametrize("shape", [(100, 5)], indirect=True)
 @pytest.mark.parametrize("window", [10, 30])
 @pytest.mark.parametrize("min_count", [None, "window"])
 def test_move_matrix_pandas_comp(array, func, window, min_count):
@@ -75,8 +75,8 @@ def test_move_matrix_pandas_comp(array, func, window, min_count):
     pandas_result = pandas_callable()
 
     # Convert pandas MultiIndex DataFrame to 3D array for comparison
-    n_obs = array.shape[-1]
-    n_vars = array.shape[-2]
+    n_obs = array.shape[-2]  # obs is second-to-last dimension now
+    n_vars = array.shape[-1]  # vars is last dimension now
     expected_pandas = np.full((n_obs, n_vars, n_vars), np.nan)
 
     # Only include windows where we have at least min_count observations
@@ -100,7 +100,7 @@ def test_move_matrix_pandas_min_count_simple(func_name, window, min_count):
     """Test matrix functions against pandas with different min_count values."""
     # Create test array directly
     rs = np.random.RandomState(0)
-    array = rs.rand(4, 15)
+    array = rs.rand(15, 4)
 
     # Get the function
     func = move_corrmatrix if func_name == "move_corrmatrix" else move_covmatrix
@@ -116,8 +116,8 @@ def test_move_matrix_pandas_min_count_simple(func_name, window, min_count):
     pandas_result = pandas_callable()
 
     # Convert pandas MultiIndex DataFrame to 3D array
-    n_obs = array.shape[-1]
-    n_vars = array.shape[-2]
+    n_obs = array.shape[-2]  # obs is second-to-last dimension now
+    n_vars = array.shape[-1]  # vars is last dimension now
     expected_pandas = np.full((n_obs, n_vars, n_vars), np.nan)
 
     for t in range(n_obs):


### PR DESCRIPTION
This commit adds `move_exp_nancorrmatrix` and `move_exp_nancovmatrix` to the benchmark suite.
It also refactors the benchmark summary generation to properly include matrix functions in the main 1D and 2D summary columns, using their largest 2D and 3D shapes respectively to demonstrate parallelization.
This avoids creating separate columns for matrix functions and provides a more cohesive summary.
Additionally, it updates the `README.md` to explain this special handling for matrix functions in the summary benchmark.

Co-authored-by: Claude <no-reply@anthropic.com>
