### PR TITLE
Sort axis before passing to aggregator

### DIFF
--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -206,6 +206,11 @@ class ndaggregate(NumbaBaseSimple):
             axis = tuple(range(arrays[0].ndim))
         elif not isinstance(axis, Iterable):
             axis = (axis,)
+        
+        # sorting the axis ensures that the performance is consistent
+        # regardless of the input order. Assumes c-ordered arrays since
+        # that is all numba supports
+        axis = tuple(sorted(axis))
 
         if not all(isinstance(a, np.ndarray) for a in arrays):
             raise TypeError(


### PR DESCRIPTION
Closes #402 

For the following array:
```python
import numpy as np
import numbagg

np.random.seed(42)
array = np.random.random((1000, 200, 10, 3))
```

main:
```python
In [2]: %timeit numbagg.nanmean(array, axis=(0, 1, 2))
7.03 ms ± 1.88 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [3]: %timeit numbagg.nanmean(array, axis=(2, 1, 0))
62.5 ms ± 1.88 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

This PR:
```python
In [2]: %timeit numbagg.nanmean(array, axis=(0, 1, 2))
5.44 ms ± 1.59 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [3]: %timeit numbagg.nanmean(array, axis=(2, 1, 0))
8.51 ms ± 929 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# ~7x improvement
```

If you make the later dimensions the larger ones:

```python
import numpy as np
import numbagg

np.random.seed(42)
array = np.random.random((10, 200, 1000, 3))

```

main:
```python
In [2]: %timeit numbagg.nanmean(array, axis=(0, 1, 2))
5.75 ms ± 2.14 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [3]: %timeit numbagg.nanmean(array, axis=(2, 1, 0))
31.9 ms ± 1.55 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

This PR:
```python
In [2]: %timeit numbagg.nanmean(array, axis=(0, 1, 2))
3.53 ms ± 6.78 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [3]: %timeit numbagg.nanmean(array, axis=(2, 1, 0))
6.93 ms ± 426 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# ~5x improvement
```

So the improvement does depend on the relative size of the dimensions, but it seems like sorting by axis order is an improvement either way.
