### PR TITLE
Fix release workflow virtual environment error

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -35,7 +35,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: dist
           path: dist
@@ -62,9 +62,15 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Set up Python
+        run: uv python install 3.11
+
       - name: Test installation
         run: |
           sleep 5
+          # Create a virtual environment
+          uv venv
+
           # Install dependencies from trusted PyPI first
           uv pip install numpy numba
 
@@ -72,7 +78,7 @@ jobs:
           uv pip install --index-url https://test.pypi.org/simple --no-deps numbagg
 
           # Verify installation works
-          python -c "import numbagg; print(f'Successfully installed numbagg {numbagg.__version__} from TestPyPI')"
+          uv run python -c "import numbagg; print(f'Successfully installed numbagg {numbagg.__version__} from TestPyPI')"
 
   pypi:
     needs: test-pypi


### PR DESCRIPTION
## Summary
- Fixes the release workflow failure where `uv pip install` commands were failing with "No virtual environment found" error
- The test-pypi job was missing proper virtual environment setup

## Changes
1. Added Python setup step (`uv python install 3.11`) to test-pypi job
2. Created virtual environment with `uv venv` before installing packages
3. Changed Python execution to use `uv run python` to run within the virtual environment
4. Updated `upload-artifact` from v4 to v5 for consistency with `download-artifact`

## Context
The release workflow was failing at the "Test installation" step with:
```
error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
```

This PR fixes the issue by properly setting up a virtual environment before attempting to install packages.

## Test plan
The workflow will be tested when this PR is merged and a new release is triggered.

🤖 Generated with [Claude Code](https://claude.ai/code)