### PR TITLE
Fix GitHub Actions artifact versions

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -35,7 +35,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -47,7 +47,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -87,7 +87,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist


### PR DESCRIPTION
actions/upload-artifact@v5 and actions/download-artifact@v5 don't exist yet.
The latest available version is v4.

This was causing the v0.9.2 release to fail immediately.

After this is merged, we'll need to delete and recreate the v0.9.2 tag.