### PR TITLE
Enable Dependabot support for uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
       interval: daily
     commit-message:
       prefix: "chore: "
+  - package-ecosystem: uv
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore: "


### PR DESCRIPTION
## Summary
- Adds uv package ecosystem to Dependabot configuration
- Will automatically update Python dependencies in `pyproject.toml` and keep `uv.lock` in sync
- Uses weekly update schedule for Python dependencies (while GitHub Actions remain daily)

## Context
Dependabot now supports uv as of March 2025. Since this project already uses uv (has `uv.lock` file), enabling Dependabot for the uv ecosystem will help keep dependencies up-to-date automatically.

## Test plan
- [x] Updated `.github/dependabot.yml` with uv ecosystem configuration
- [ ] Once merged, Dependabot will start checking for Python dependency updates weekly

🤖 Generated with [Claude Code](https://claude.ai/code)