### PR TITLE
chore: grant standing exception for filing issues in agent-equipped repos

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -2,6 +2,13 @@
 
 Tend-specific CI guidance. Project conventions are in CLAUDE.md.
 
+## Filing issues in other repos
+
+Standing exception granted: file directly in agent-equipped targets (per
+**Filing Issues in Other Repos** in the bundled `running-in-ci` skill) without
+asking permission here first. The default rule (open an issue here asking
+permission first) still applies when the target shows no agent signals.
+
 ## CI workflows
 
 - **Test** — the main CI workflow (`test.yaml`). Runs tests, linting,


### PR DESCRIPTION
Grants a standing exception for cross-repo issue filing, paired with the bundled-skill rule landing in `max-sixty/tend` (see [max-sixty/tend#509](https://github.com/max-sixty/tend/pull/509)).

Tend's default behaviour is: open an issue in the current repo asking permission first. This overlay grants a standing exception so the bot files directly in **agent-equipped** targets — repos with their own coding agent, detected from tend workflows, `claude-code-action` use, or recent bot-authored PRs/issues with no human pushback.

A no-op until tend's next release ships the new bundled section; safe to land in any order.
