### PR TITLE
chore: roll back to the default claude harness

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -1,5 +1,4 @@
 bot_name: numbagg-bot
-harness: claude-interactive
 setup:
 - uses: astral-sh/setup-uv@v7
 - run: uv sync

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - run: uv sync
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -210,7 +210,7 @@ jobs:
         env:
           EVENT_TS: ${{ github.event.comment.updated_at || github.event.review.submitted_at || github.event.issue.updated_at }}
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - run: uv sync
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -101,7 +101,7 @@ jobs:
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
       - run: uv sync
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - run: uv sync
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -51,7 +51,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - run: uv sync
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - run: uv sync
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - run: uv sync
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Anthropic [paused](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) the 2026-06-15 Agent SDK credit metering (the `-p` billing change), so subscription `claude-code-action` runs again draw from the plan's usage limits. That removes the reason this repo was on the `claude-interactive` harness.

- `.config/tend.yaml`: drop `harness: claude-interactive` (the default is `claude`).
- Regenerate `tend-*.yaml` via `uvx tend@latest init`: the action ref goes from `max-sixty/tend/interactive@0.1.4` to `max-sixty/tend@0.1.4` across all eight workflows.

Auth is unchanged: both harnesses use the same secrets.

> _This was written by Claude Code on behalf of max_
