### PR TITLE
docs(tend): note why `setup:` keeps setup-uv and `uv sync`

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -1,4 +1,7 @@
 bot_name: numbagg-bot
+# The agent runs everything through `uv run` (CLAUDE.md); setup-uv is where it
+# gets uv. `uv sync` warms `.venv`, which the sandbox inherits along with the
+# workspace, so `uv run` only syncs what the PR changed.
 setup:
 - uses: astral-sh/setup-uv@v7
 - run: uv sync


### PR DESCRIPTION
Adopter `setup:` steps now run against the PR's base tree upstream (max-sixty/tend#806), which makes numbagg's `uv sync` look misplaced: tend's docs now point project dependency installs at `sandbox_setup:`. It isn't misplaced, and this records why before someone moves it.

`setup-sandbox.sh` hands the whole workspace to the sandbox user, so the agent inherits the `.venv` that `uv sync` built, and the PR checkout keeps it (`clean: false`, and `.venv` is untracked). In a real numbagg review run the agent's `uv run pytest` rebuilt one package rather than installing 41. Moving the sync to `sandbox_setup:` would pay a full cold sync as the sandbox user on every run, including the ones that never touch Python; dropping it would pay that same cold sync on the runs that do, since `sudo env` resets the environment and the runner's `UV_CACHE_DIR` never crosses into the sandbox. Neither is expensive in absolute terms, the two runner steps cost about 5s combined, but on a dependency-bump PR (most of numbagg's traffic) the current arrangement fetches one wheel instead of 41.

`setup-uv` is separately load-bearing now that tend installs no uv of its own into the sandbox (max-sixty/tend#807). Without it the agent can't honour CLAUDE.md's `uv run` prefix, so it could run neither the tests nor `ty check`.

The comment is worded to hold both before and after the next tend release, since numbagg is still generating from the 0.1.12 templates. Regenerating with `uvx tend@0.1.12 init` produces byte-identical workflows.

> _This was written by Claude Code on behalf of max-sixty_
