### PR TITLE
Order the benchmark summary table deterministically

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,10 +312,10 @@ numbagg/test/run_benchmarks.py -- --benchmark-max-time=10`. They run in CI,
     on parallelizable arrays.
 
 [^6]:
-    Matrix functions (correlation/covariance matrices) use different array shapes
-    in the summary benchmark: their **largest 2D shape** appears in the 1D column
-    and their **largest 3D shape** appears in the 2D column to demonstrate
-    parallelization across multiple independent matrices.
+    Matrix functions (correlation/covariance matrices) have no 1D benchmark — the
+    smallest input they accept is 2D — so their **largest 2D shape** appears in the
+    1D column. The 2D column has no entry for them, because no comparison library
+    accepts more than two dimensions.
 
 ## Axis parameter behavior
 

--- a/numbagg/test/run_benchmarks.py
+++ b/numbagg/test/run_benchmarks.py
@@ -61,30 +61,10 @@ def _func_label(func_name: str) -> str:
     return f"`{func_name}`[^5]"
 
 
-def run(k_filter, run_tests, extra_args):
-    import jq  # ty:ignore[unresolved-import]
+def markdown_tables(records: list[dict]) -> tuple[str, str]:
+    """The summary and full benchmark tables as markdown, from `_JQ_PROGRAM`'s output."""
 
-    json_path = Path(".benchmarks/benchmark.json")
-    json_path.parent.mkdir(exist_ok=True, parents=True)
-    if run_tests:
-        subprocess.run(
-            [
-                "pytest",
-                "-vv",
-                "numbagg/test/test_benchmark.py",
-                f"-k={k_filter}",
-                "--benchmark-enable",
-                "--benchmark-only",
-                "--run-nightly",
-                f"--benchmark-json={json_path}",
-            ]
-            + extra_args,
-            check=True,
-        )
-
-    json = jq.compile(_JQ_PROGRAM).input(text=json_path.read_text())
-
-    df = pd.DataFrame.from_dict(json.all())
+    df = pd.DataFrame(records)
 
     df = (
         df.assign(size=lambda x: x["shape"].map(lambda x: np.prod(x)))
@@ -142,29 +122,23 @@ def run(k_filter, run_tests, extra_args):
     ].rename_axis(columns=None)
 
     def make_summary_df(df, nd: int):
-        """Create summary DataFrame for benchmark results.
+        """Ratios at one dimensionality, indexed by func with a column per shape.
 
-        Matrix functions require special handling to appear in main summary columns:
-        - nd=1 (1D column): Use their LARGEST 2D matrix shape
-        - nd=2 (2D column): Use their LARGEST 3D matrix shape (demonstrates parallelization)
-
-        This allows matrix functions to demonstrate parallelization without separate columns.
+        Matrix functions have no 1D benchmark — the smallest input they accept is 2D —
+        so the 1D column falls back to their largest 2D shape. They're absent from the
+        2D column, because no comparison library accepts more than two dimensions and
+        so there's nothing to compare a parallelized matrix run against.
         """
 
-        def process_functions(func_df, target_ndim, source_df=None):
-            """Process a subset of functions with target dimensionality."""
-            if source_df is None:
-                source_df = func_df
-
-            filtered = func_df[lambda x: x["ndim"] == target_ndim]
+        def ratios_at_largest_shape(func_df, ndim):
+            filtered = func_df[lambda x: x["ndim"] == ndim]
             if filtered.empty:
                 return None
 
             # Use largest array shape for performance comparison
             shape = filtered.sort_values(by="size")["shape"].iloc[-1]
             return (
-                source_df.query(f"shape == '{shape}'")
-                .reset_index()
+                func_df.query(f"shape == '{shape}'")
                 .set_index(["func", "shape"])
                 .unstack("shape")  # Pivot: functions as rows, shapes as columns
                 .pipe(
@@ -172,139 +146,65 @@ def run(k_filter, run_tests, extra_args):
                         [
                             c
                             for c in x.columns
-                            if c[0].endswith("ratio") and c[0] not in ["numbagg_ratio"]
+                            if c[0].endswith("ratio") and c[0] != "numbagg_ratio"
                         ]
                     ]
                 )
             )
 
-        # Split data by matrix vs non-matrix functions
-        matrix_df = df[df["func"].str.contains("matrix", na=False)]
-        non_matrix_df = df[~df["func"].str.contains("matrix", na=False)]
-
-        results = []
-
-        # Process non-matrix functions: use regular dimensionality (1D→1D, 2D→2D)
-        if not non_matrix_df.empty:
-            regular_result = process_functions(non_matrix_df, nd)
-            if regular_result is not None:
-                results.append(regular_result)
-
-        # Process matrix functions: use special dimensionality mapping
-        if not matrix_df.empty:
-            matrix_target_ndim = {1: 2, 2: 3}.get(nd)  # 1D→2D, 2D→3D
-            if matrix_target_ndim:
-                matrix_result = process_functions(
-                    matrix_df, matrix_target_ndim, matrix_df
-                )
-                if matrix_result is not None:
-                    results.append(matrix_result)
-
-        # Combine all results into single DataFrame
+        is_matrix = df["func"].str.contains("matrix", na=False)
+        results = [ratios_at_largest_shape(df[~is_matrix], nd)]
+        if nd == 1:
+            results.append(ratios_at_largest_shape(df[is_matrix], 2))
+        results = [r for r in results if r is not None]
         return pd.concat(results, axis=0) if results else pd.DataFrame()
 
-    def get_column_value(summary_df, func, lib, dimension, matrix_shape_exclusions):
-        """Extract column value for a function/library pair with matrix function handling."""
-        matching_cols = [
-            col for col in summary_df.columns if col[0].removesuffix("_ratio") == lib
-        ]
+    def summary_value(summary_df, func, lib):
+        """The ratio for a function/library pair, from whichever shape column holds it.
 
-        if not matching_cols or func not in summary_df.index:
+        Concatenating the matrix and non-matrix frames leaves one column per shape, and
+        each function has a value in exactly one of them.
+        """
+        if func not in summary_df.index:
             return "n/a"
+        values = summary_df.loc[
+            func, [c for c in summary_df.columns if c[0].removesuffix("_ratio") == lib]
+        ].dropna()
+        return values.iloc[0] if len(values) else "n/a"
 
-        # For matrix functions, try to find matrix-specific column first
-        value = None
-        if "matrix" in func:
-            matrix_cols = [
-                col
-                for col in matching_cols
-                if not any(exclusion in col[1] for exclusion in matrix_shape_exclusions)
-            ]
-            if matrix_cols:
-                value = summary_df.loc[func, matrix_cols[0]]
+    summaries = [(nd, make_summary_df(df, nd)) for nd in (1, 2)]
 
-        # Fallback to first column if no matrix-specific column found
-        if value is None:
-            value = summary_df.loc[func, matching_cols[0]]
+    summary_funcs = set().union(*(summary_df.index for _, summary_df in summaries))
+    # Rows follow the order `_sort_key` established above
+    funcs = [func for func in df["func"].drop_duplicates() if func in summary_funcs]
+    # Columns follow the library order of the full benchmark table below
 
-        return value if not pd.isna(value) else "n/a"
-
-    def process_dimension_data(
-        summary_df, func, dimension, all_libs, matrix_shape_exclusions
-    ):
-        """Process data for a single dimension (1D or 2D) for a specific function."""
-        if summary_df.empty:
-            return {f"{dimension}_{lib}": "n/a" for lib in all_libs}
-
-        return {
-            f"{dimension}_{lib}": get_column_value(
-                summary_df, func, lib, dimension, matrix_shape_exclusions
-            )
-            for lib in all_libs
-        }
-
-    # Create summaries including matrix functions in main 1D/2D columns
-    summary_1d = make_summary_df(df, 1)
-    summary_2d = make_summary_df(df, 2)
-
-    # Matrix function shape exclusion patterns
-    matrix_exclusions = {"1D": ["(10000000,)"], "2D": ["(100, 100000)"]}
-
-    # Combine summaries properly - reorganize to have 1D/2D structure
-    if summary_1d.empty and summary_2d.empty:
-        summary = pd.DataFrame()
-    else:
-        # Extract unique libraries and functions
-        libs_1d = (
-            set(col[0].removesuffix("_ratio") for col in summary_1d.columns)
-            if not summary_1d.empty
-            else set()
+    summary_libs = [
+        lib
+        for lib in libraries
+        if lib != "numbagg"
+        and any(
+            c[0].removesuffix("_ratio") == lib
+            for _, summary_df in summaries
+            for c in summary_df.columns
         )
-        libs_2d = (
-            set(col[0].removesuffix("_ratio") for col in summary_2d.columns)
-            if not summary_2d.empty
-            else set()
-        )
-        all_libs = sorted(libs_1d | libs_2d)
-        all_functions = set(summary_1d.index if not summary_1d.empty else []) | set(
-            summary_2d.index if not summary_2d.empty else []
-        )
+    ]
 
-        # Create properly structured summary
-        summary_data = []
-        for func in all_functions:
-            row = {"func": func}
-
-            # Process 1D and 2D dimensions
-            for dim, summary_df, exclusions in [
-                ("1D", summary_1d, matrix_exclusions["1D"]),
-                ("2D", summary_2d, matrix_exclusions["2D"]),
-            ]:
-                dim_data = process_dimension_data(
-                    summary_df, func, dim, all_libs, exclusions
-                )
-                row.update(dim_data)
-
-            summary_data.append(row)
-
-        summary = pd.DataFrame(summary_data).set_index("func")
-
-    if not summary.empty:
-        summary = summary.reset_index()
-        values = summary.to_dict(index=False, orient="split")["data"]
-
-        # Generate headers from the new column structure (1D_pandas, 2D_pandas, etc.)
-        headers = ["func"]
-        for col in summary.columns[1:]:
-            # Column names are like "1D_pandas", "2D_numpy"
-            dimension, library = col.split("_", 1)
-            headers.append(f"{dimension}<br>{library}")
-
+    if funcs and summary_libs:
         summary_markdown = tabulate(
-            values,
-            headers=headers,
+            [
+                [func]
+                + [
+                    summary_value(summary_df, func, lib)
+                    for _, summary_df in summaries
+                    for lib in summary_libs
+                ]
+                for func in funcs
+            ],
+            headers=["func"]
+            + [f"{nd}D<br>{lib}" for nd, _ in summaries for lib in summary_libs],
             disable_numparse=True,
-            colalign=["left"] + ["right"] * (len(summary.columns) - 1),
+            colalign=["left"] + ["right"] * (len(summaries) * len(summary_libs)),
             tablefmt="pipe",
         )
     else:
@@ -321,6 +221,33 @@ def run(k_filter, run_tests, extra_args):
         colalign=["left"] + ["right"] * (len(full.columns) - 1),
         tablefmt="pipe",
     )
+
+    return summary_markdown, full_markdown
+
+
+def run(k_filter, run_tests, extra_args):
+    import jq  # ty:ignore[unresolved-import]
+
+    json_path = Path(".benchmarks/benchmark.json")
+    json_path.parent.mkdir(exist_ok=True, parents=True)
+    if run_tests:
+        subprocess.run(
+            [
+                "pytest",
+                "-vv",
+                "numbagg/test/test_benchmark.py",
+                f"-k={k_filter}",
+                "--benchmark-enable",
+                "--benchmark-only",
+                "--run-nightly",
+                f"--benchmark-json={json_path}",
+            ]
+            + extra_args,
+            check=True,
+        )
+
+    records = jq.compile(_JQ_PROGRAM).input(text=json_path.read_text()).all()
+    summary_markdown, full_markdown = markdown_tables(records)
 
     text = f"""
 ### Summary benchmark

--- a/numbagg/test/test_run_benchmarks.py
+++ b/numbagg/test/test_run_benchmarks.py
@@ -2,14 +2,16 @@
 
 These cover the parts that silently mishandled functions which aren't decorated
 gufuncs — `nanmedian` is a plain wrapper around `nanquantile`, so it has neither
-`numbagg.<name>` as its `__repr__` nor a `supports_parallel` attribute.
+`numbagg.<name>` as its `__repr__` nor a `supports_parallel` attribute — and the
+assembly of the summary table, whose rows and columns have to come out in a stable
+order for the README's committed copy to be diffable.
 """
 
 import json
 
 import pytest
 
-from .run_benchmarks import _JQ_PROGRAM, _func_label
+from .run_benchmarks import _JQ_PROGRAM, _func_label, markdown_tables
 
 
 @pytest.fixture(scope="module")
@@ -93,3 +95,96 @@ def test_jq_raises_on_unrecognized_repr(jq):
 )
 def test_func_label(func_name, expected):
     assert _func_label(func_name) == expected
+
+
+# The shapes and comparison libraries each function is benchmarked over, mirroring
+# `test_benchmark.py` and `conftest.py`: matrix functions have no 1D benchmark, and
+# only pandas to compare against.
+_BENCHMARKED = {
+    "move_mean": ([(10_000_000,), (100, 100_000)], ["numbagg", "pandas", "bottleneck"]),
+    "move_exp_nanmean": ([(10_000_000,), (100, 100_000)], ["numbagg", "pandas"]),
+    "nancorrmatrix": ([(5, 100_000), (3_000, 5, 1_000)], ["numbagg", "pandas"]),
+    "nanmean": ([(10_000_000,), (100, 100_000)], ["numbagg", "pandas", "numpy"]),
+    "nansum": ([(10_000_000,), (100, 100_000)], ["numbagg", "pandas", "numpy"]),
+}
+
+
+@pytest.fixture
+def records():
+    """One record per (func, library, shape), as `_JQ_PROGRAM` emits them.
+
+    Every comparison library takes twice as long as numbagg, so each populated cell
+    reads `2.00x` and anything else is a gap in the benchmark rather than a slow run.
+    """
+    return [
+        {
+            "func": func,
+            "library": library,
+            "shape": list(shape),
+            "time": 0.001 if library == "numbagg" else 0.002,
+            "group": f"{func}|{shape}",
+        }
+        for func, (shapes, libraries) in _BENCHMARKED.items()
+        for shape in shapes
+        for library in libraries
+        # No comparison library takes more than 2 dimensions
+        if library == "numbagg" or len(shape) <= 2
+    ]
+
+
+def _cells(markdown: str) -> list[list[str]]:
+    """The header row and body rows of a pipe-format markdown table."""
+    rows = [
+        [cell.strip() for cell in line.strip("|").split("|")]
+        for line in markdown.splitlines()
+        if line.startswith("|")
+    ]
+    return [rows[0]] + rows[2:]  # rows[1] is tabulate's alignment separator
+
+
+def test_summary_header(records):
+    header, *_ = _cells(markdown_tables(records)[0])
+    # Libraries in the order the full table below uses, not alphabetical
+    assert header == [
+        "func",
+        "1D<br>pandas",
+        "1D<br>bottleneck",
+        "1D<br>numpy",
+        "2D<br>pandas",
+        "2D<br>bottleneck",
+        "2D<br>numpy",
+    ]
+
+
+def test_summary_row_order(records):
+    # Previously the rows came from a set, so the order — and hence the README diff of
+    # a regenerated table — was arbitrary. It should follow `_sort_key`, which groups
+    # `move_exp_*` after all the plain `move_*` functions.
+    _, *body = _cells(markdown_tables(records)[0])
+    assert [row[0] for row in body] == [
+        "`move_mean`",
+        "`move_exp_nanmean`",
+        "`nancorrmatrix`[^6]",
+        "`nanmean`",
+        "`nansum`",
+    ]
+
+
+def test_summary_matrix_function_uses_its_2d_shape(records):
+    # The 1D column falls back to a matrix function's largest 2D shape; its 2D column
+    # is empty because nothing else takes the 3D input.
+    _, *body = _cells(markdown_tables(records)[0])
+    rows = {row[0]: row[1:] for row in body}
+    assert rows["`nancorrmatrix`[^6]"] == ["2.00x", "n/a", "n/a", "n/a", "n/a", "n/a"]
+    assert rows["`nanmean`"] == ["2.00x", "n/a", "2.00x", "2.00x", "n/a", "2.00x"]
+
+
+def test_full_table_keeps_every_shape(records):
+    header, *body = _cells(markdown_tables(records)[1])
+    shapes = [row[header.index("shape")] for row in body]
+    assert sorted(set(shapes)) == [
+        "(100, 100000)",
+        "(10000000,)",
+        "(3000, 5, 1000)",
+        "(5, 100000)",
+    ]


### PR DESCRIPTION
The summary table's rows came from a `set`, so each regeneration emitted them in a different order and the diff against the README's committed copy was unreadable. Rows now follow the same `_sort_key` order as the full table below, and the library columns follow the full table's order — pandas, bottleneck, numpy — rather than alphabetical.

Matrix functions no longer map their largest 3D shape into the 2D column. No comparison library accepts more than two dimensions, so that column only ever held `n/a`. Without it each function has a value under exactly one shape, so picking the first non-null value replaces the hardcoded lists of shapes to exclude. The rendered table is unchanged by this part, but footnote `[^6]` described that mapping, so it's rewritten to match.

`markdown_tables` is now separate from `run`, so the table assembly can be tested without a benchmark run behind it. The new tests cover row order, column order, the matrix shape convention, and that every benchmarked shape reaches the full table.

Groundwork for #721, which needs a stable row order before the README's tables can be regenerated usefully. The regenerated tables follow in a second PR, once a full benchmark run finishes on a maintainer's machine — GitHub's runners have too few cores to produce comparable parallel numbers.

Ref #721

> _This was written by Claude Code on behalf of max-sixty_
