### PR TITLE
skills(running-tend): add frontmatter

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: running-tend
-description: numbagg-specific guidance for tend CI workflows. Adds which CI workflow to watch, two-pass polling for the long benchmark job, nightly-survey expectations, and dependency management on top of the generic tend-* skills. Use when operating in CI.
+description: numbagg-specific guidance for tend CI workflows. Adds a standing exception for filing issues in other repos, which CI workflow to watch, two-pass polling for the long benchmark job, nightly-survey expectations, and dependency management on top of the generic tend-* skills. Use when operating in CI.
 ---
 
 # Running Tend — numbagg

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: running-tend
-description: numbagg-specific guidance for tend CI workflows. Adds the CI workflow map, two-pass polling for the long benchmark job, nightly-survey expectations, and dependency management on top of the generic tend-* skills. Use when operating in CI.
+description: numbagg-specific guidance for tend CI workflows. Adds which CI workflow to watch, two-pass polling for the long benchmark job, nightly-survey expectations, and dependency management on top of the generic tend-* skills. Use when operating in CI.
 ---
 
 # Running Tend — numbagg

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: running-tend
+description: numbagg-specific guidance for tend CI workflows. Adds the CI workflow map, two-pass polling for the long benchmark job, nightly-survey expectations, and dependency management on top of the generic tend-* skills. Use when operating in CI.
+---
+
 # Running Tend — numbagg
 
 Tend-specific CI guidance. Project conventions are in CLAUDE.md.


### PR DESCRIPTION
`.claude/skills/running-tend/SKILL.md` had no YAML frontmatter. Claude Code discovers the file anyway, but falls back to the directory name and the file's first heading, so a CI session saw it listed as `running-tend: Running Tend — numbagg`. The overlay still got loaded — the bundled `running-in-ci` skill tells the bot to load `running-tend` whenever it appears in the skill list — but an agent judges relevance from that line, and an H1 says nothing about what the file contains.

The frontmatter names the skill and describes what this overlay carries: the standing exception for filing issues in other repos, which CI workflow to watch, the two-pass polling rule for the long `benchmark` job, the empty nightly survey, and dependency management. The guidance itself is unchanged, and the frontmatter matches what tend's installer now stamps for new overlays.

Checked on Claude Code 2.1.235 (tend's action pins 2.1.233) by listing the available skills in a checkout with and without the change.

> _This was written by Claude Code on behalf of max-sixty_
