### PR TITLE
Stabilize scalar rolling moments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,18 @@ The library provides aggregation functions (like `nansum`, `nanmean`), moving wi
 
 Public functions in `funcs.py`, `moving.py`, and `moving_exp.py` — including the matrix functions `moving.py` re-exports — are mirrored in `.pyi` stubs, which the `stubtest` pre-commit hook checks. Add or rename one and update its stub; a decorated gufunc also needs an entry in `stubtest_allowlist.txt`. `grouped.py` has no stub.
 
+## Numerical Algorithms
+
+When changing variance, covariance, or correlation algorithms:
+
+- Preserve causality, pairwise-NaN semantics, and dtype/output contracts. Variances and covariance diagonals must not be meaningfully negative. Correlations must remain within `[-1, 1]`; clipping is a final guard, not an accuracy fix.
+- Optimize dense and NaN-heavy, zero-centered float32 and float64 workloads. Target at most 5% median regression, and investigate any individual regression above 10%. Treat differences within benchmark noise as ties.
+- Let ill-conditioned inputs pay for stability. Measure large offsets, long series, expired outliers, regime changes, and nearly constant data separately, including fallback or reanchor frequency.
+- Prefer one stable algorithm when its ordinary-case performance is competitive. Add a fast path only for a material win, and use a conservative trigger that scales with the observation count.
+- Share one statistical state across variance and covariance and derive standard deviation and correlation from it. Avoid duplicate implementations and forwarding-only helpers.
+- Compare accuracy with exact arithmetic or a high-precision or two-pass reference. Normalize covariance error by the variables' spread when true covariance is near zero.
+- Report steady-state runtime, cold compilation, scratch memory, dtype promotion, and fallback or reanchor frequency. Matrix implementations preserve upper-triangle iteration.
+
 ## Running Commands
 
 Prefix commands with `uv run` to ensure that the correct virtual environment is used. For example:

--- a/numbagg/moving.py
+++ b/numbagg/moving.py
@@ -1,12 +1,802 @@
 from typing import TypeVar
 
 import numpy as np
-from numba import float32, float64, int64
+from numba import float32, float64, int64, njit
 
-from .decorators import ndmove
+from .decorators import _ENABLE_CACHE, ndmove
 from .utils import FloatArray
 
 T = TypeVar("T", bound=FloatArray)
+
+
+FLOAT32_EPSILON = np.finfo(np.float32).eps
+FLOAT64_EPSILON = np.finfo(np.float64).eps
+FLOAT32_SQRT_EPSILON = np.sqrt(FLOAT32_EPSILON)
+FLOAT64_SQRT_EPSILON = np.sqrt(FLOAT64_EPSILON)
+# If one magnitude is eps**(-1/4) larger than every other magnitude, its squared
+# contribution is eps**(-1/2) larger. Adding and later removing it can therefore
+# discard more than sqrt(eps) of the remaining second-moment state.
+FLOAT32_EPSILON_QUARTER = np.sqrt(FLOAT32_SQRT_EPSILON)
+FLOAT64_EPSILON_QUARTER = np.sqrt(FLOAT64_SQRT_EPSILON)
+
+# A trailing cluster needs four observations (three adjacent differences) before
+# it is treated as a new low-spread regime. One close pair is common in ordinary
+# data and is not enough evidence to abandon the raw path. This is an event
+# filter, not a coefficient in the roundoff bound.
+MIN_CONTRACTION_EDGES = 3
+
+
+@njit(cache=_ENABLE_CACHE, inline="never")
+def _move_variance_stable_suffix(a, window, min_count, out, start, take_sqrt):
+    """Overwrite ``out[start:]`` using causally shifted float64 moments.
+
+    Keeping this recovery loop out of line is a measured performance choice: even
+    a never-taken copy of its state machine inside the raw loop materially slows
+    ordinary inputs. Difficult inputs pay for this second pass instead.
+    """
+    total = 0.0
+    total_sq = 0.0
+    origin = 0.0
+    origin_index = -1
+    count = 0
+    updates = 0
+
+    for i in range(start, len(a)):
+        dominant_exited = False
+        origin_expired = False
+        if i > start:
+            if i >= window:
+                old = np.float64(a[i - window])
+                if not np.isnan(old):
+                    centered_old = old - origin
+                    product_old = centered_old * centered_old
+                    remaining_sq = total_sq - product_old
+                    # If one contribution is more than 1 / sqrt(eps) times the
+                    # rest, adding and removing it can discard more than
+                    # sqrt(eps) of the smaller state. Recompute once it leaves.
+                    dominant_exited = count >= 2 and abs(
+                        product_old
+                    ) * FLOAT64_SQRT_EPSILON > abs(remaining_sq)
+                    total -= centered_old
+                    total_sq = remaining_sq
+                    count -= 1
+                    updates += 1
+                    origin_expired = origin_index == i - window
+
+            value = np.float64(a[i])
+            if not np.isnan(value):
+                if count == 0:
+                    origin = value
+                    origin_index = i
+                    total = 0.0
+                    total_sq = 0.0
+                    updates = 0
+                centered = value - origin
+                product = centered * centered
+                total += centered
+                total_sq += product
+                count += 1
+                updates += 1
+
+        needs_rescan = i == start or origin_expired or dominant_exited
+        if count >= min_count:
+            correction = total * total / count
+            numerator = total_sq - correction
+            roundoff_fraction = updates * FLOAT64_EPSILON
+            condition_scale = abs(total_sq) + abs(correction)
+            needs_rescan = needs_rescan or (
+                not np.isfinite(numerator)
+                or numerator < 0.0
+                or roundoff_fraction * condition_scale > abs(numerator)
+            )
+
+        if needs_rescan:
+            window_start = max(0, i - window + 1)
+            # Use the newest valid value: unlike the oldest value, it cannot
+            # expire on the next update and leave a stale origin behind.
+            for j in range(i, window_start - 1, -1):
+                value = np.float64(a[j])
+                if not np.isnan(value):
+                    origin = value
+                    origin_index = j
+                    break
+            total = 0.0
+            total_sq = 0.0
+            count = 0
+            updates = 0
+            for j in range(window_start, i + 1):
+                value = np.float64(a[j])
+                if not np.isnan(value):
+                    centered = value - origin
+                    product = centered * centered
+                    total += centered
+                    total_sq += product
+                    count += 1
+                    updates += 1
+
+            if count >= min_count:
+                correction = total * total / count
+                numerator = total_sq - correction
+
+        if count >= min_count:
+            variance = max(numerator / (count - 1), 0.0)
+            out[i] = np.sqrt(variance) if take_sqrt else variance
+        else:
+            out[i] = np.nan
+
+
+@njit(cache=_ENABLE_CACHE, inline="always")
+def _move_variance(a, window, min_count, out, take_sqrt):
+    """Raw rolling variance core shared by ``move_var`` and ``move_std``."""
+    total = 0.0
+    total_sq = 0.0
+    count = 0
+    trigger_index = -1
+    input_epsilon = FLOAT32_EPSILON if a.itemsize == 4 else FLOAT64_EPSILON
+    sqrt_input_epsilon = (
+        FLOAT32_SQRT_EPSILON if a.itemsize == 4 else FLOAT64_SQRT_EPSILON
+    )
+    min_count = max(min_count, 2)
+
+    for i in range(len(a)):
+        dominant_exited = False
+        if i >= window:
+            old = a[i - window]
+            if not np.isnan(old):
+                product_old = old * old
+                remaining_sq = total_sq - product_old
+                # See the stable suffix for the derivation of sqrt(eps). Squared
+                # terms are non-negative, so the remaining square sum is a
+                # non-cancelling scale for this comparison.
+                dominant_exited = count >= 2 and abs(
+                    np.float64(product_old)
+                ) * sqrt_input_epsilon > abs(np.float64(remaining_sq))
+                total -= old
+                total_sq = remaining_sq
+                count -= 1
+
+        value = a[i]
+        if not np.isnan(value):
+            total += value
+            total_sq += value * value
+            count += 1
+
+        # Recover even if this window is below min_count and emits NaN; otherwise
+        # the one-time destructive removal would be forgotten.
+        if dominant_exited:
+            trigger_index = i
+            break
+
+        if count >= min_count:
+            correction = total * total / count
+            numerator = total_sq - correction
+            # The input epsilon covers product rounding in its dtype; the update
+            # count covers the float64 accumulators' addition/removal error.
+            # Unlike a fixed coefficient, the bound grows with the history that
+            # produced this state.
+            roundoff_fraction = input_epsilon + (
+                max(i + 1, 2 * (i + 1) - window) * FLOAT64_EPSILON
+            )
+            condition_scale = abs(total_sq) + abs(correction)
+            if (
+                (a.itemsize == 4 and count == 2)
+                or not np.isfinite(numerator)
+                or numerator < 0.0
+                or roundoff_fraction * condition_scale > abs(numerator)
+            ):
+                trigger_index = i
+                break
+
+            variance = max(numerator / (count - 1), 0.0)
+            out[i] = np.sqrt(variance) if take_sqrt else variance
+        else:
+            out[i] = np.nan
+
+    if trigger_index >= 0:
+        _move_variance_stable_suffix(
+            a, window, min_count, out, trigger_index, take_sqrt
+        )
+
+
+@njit(cache=_ENABLE_CACHE, inline="never")
+def _inspect_pairwise_window(a, b, end, window):
+    """Return non-cancelling scale information for one causal window."""
+    start = max(0, end - window + 1)
+    minimum_a = np.inf
+    maximum_a = -np.inf
+    minimum_b = np.inf
+    maximum_b = -np.inf
+    largest_a = 0.0
+    runner_up_a = 0.0
+    largest_index_a = -1
+    largest_b = 0.0
+    runner_up_b = 0.0
+    largest_index_b = -1
+    total_sq_a = 0.0
+    total_sq_b = 0.0
+    for j in range(start, end + 1):
+        value_a = np.float64(a[j])
+        value_b = np.float64(b[j])
+        if not (np.isnan(value_a) or np.isnan(value_b)):
+            minimum_a = min(minimum_a, value_a)
+            maximum_a = max(maximum_a, value_a)
+            minimum_b = min(minimum_b, value_b)
+            maximum_b = max(maximum_b, value_b)
+            magnitude_a = abs(value_a)
+            magnitude_b = abs(value_b)
+            if magnitude_a > largest_a:
+                runner_up_a = largest_a
+                largest_a = magnitude_a
+                largest_index_a = j
+            elif magnitude_a > runner_up_a:
+                runner_up_a = magnitude_a
+            if magnitude_b > largest_b:
+                runner_up_b = largest_b
+                largest_b = magnitude_b
+                largest_index_b = j
+            elif magnitude_b > runner_up_b:
+                runner_up_b = magnitude_b
+            # Float32 products are promoted on the raw path and do not need the
+            # startup cancellation bound. Numba removes this branch per signature.
+            if a.itemsize == 8:
+                total_sq_a += value_a * value_a
+                total_sq_b += value_b * value_b
+    return (
+        minimum_a,
+        maximum_a,
+        minimum_b,
+        maximum_b,
+        largest_a,
+        runner_up_a,
+        largest_index_a,
+        largest_b,
+        runner_up_b,
+        largest_index_b,
+        total_sq_a,
+        total_sq_b,
+    )
+
+
+@njit(cache=_ENABLE_CACHE, inline="never")
+def _trailing_pair_boundaries(a, b, end, window, threshold_a, threshold_b):
+    """Find an older regime followed by a sustained low-spread trailing cluster."""
+    start = max(0, end - window + 1)
+    previous_a = 0.0
+    previous_b = 0.0
+    have_previous = False
+    active_a = True
+    active_b = True
+    small_edges_a = 0
+    small_edges_b = 0
+    boundary_a = -1
+    boundary_b = -1
+    for j in range(end, start - 1, -1):
+        value_a = np.float64(a[j])
+        value_b = np.float64(b[j])
+        if not (np.isnan(value_a) or np.isnan(value_b)):
+            if not have_previous:
+                previous_a = value_a
+                previous_b = value_b
+                have_previous = True
+            else:
+                if active_a:
+                    if abs(previous_a - value_a) <= threshold_a:
+                        small_edges_a += 1
+                    else:
+                        if small_edges_a >= MIN_CONTRACTION_EDGES:
+                            boundary_a = j
+                        active_a = False
+                if active_b:
+                    if abs(previous_b - value_b) <= threshold_b:
+                        small_edges_b += 1
+                    else:
+                        if small_edges_b >= MIN_CONTRACTION_EDGES:
+                            boundary_b = j
+                        active_b = False
+                previous_a = value_a
+                previous_b = value_b
+                if not (active_a or active_b):
+                    break
+    return boundary_a, boundary_b
+
+
+@njit(cache=_ENABLE_CACHE, inline="never")
+def _move_covariance_stable_suffix(a, b, window, min_count, out, start, correlation):
+    """Overwrite a suspicious covariance/correlation suffix with shifted moments."""
+    total_a = 0.0
+    total_b = 0.0
+    total_ab = 0.0
+    total_abs_ab = 0.0
+    total_sq_a = 0.0
+    total_sq_b = 0.0
+    origin_a = 0.0
+    origin_b = 0.0
+    origin_index = -1
+    count = 0
+    updates = 0
+
+    for i in range(start, len(a)):
+        dominant_exited = False
+        origin_expired = False
+        if i > start:
+            if i >= window:
+                old_a = np.float64(a[i - window])
+                old_b = np.float64(b[i - window])
+                if not (np.isnan(old_a) or np.isnan(old_b)):
+                    centered_old_a = old_a - origin_a
+                    centered_old_b = old_b - origin_b
+                    product_old = centered_old_a * centered_old_b
+                    total_a -= centered_old_a
+                    total_b -= centered_old_b
+                    total_ab -= product_old
+                    if correlation:
+                        product_sq_a = centered_old_a * centered_old_a
+                        product_sq_b = centered_old_b * centered_old_b
+                        remaining_sq_a = total_sq_a - product_sq_a
+                        remaining_sq_b = total_sq_b - product_sq_b
+                        dominant_exited = dominant_exited or (
+                            count >= 2
+                            and (
+                                abs(product_sq_a) * FLOAT64_SQRT_EPSILON
+                                > abs(remaining_sq_a)
+                                or abs(product_sq_b) * FLOAT64_SQRT_EPSILON
+                                > abs(remaining_sq_b)
+                            )
+                        )
+                        total_sq_a = remaining_sq_a
+                        total_sq_b = remaining_sq_b
+                    else:
+                        remaining_abs_ab = total_abs_ab - abs(product_old)
+                        dominant_exited = count >= 2 and abs(
+                            product_old
+                        ) * FLOAT64_SQRT_EPSILON > abs(remaining_abs_ab)
+                        total_abs_ab = remaining_abs_ab
+                    count -= 1
+                    updates += 1
+                    origin_expired = origin_index == i - window
+
+            value_a = np.float64(a[i])
+            value_b = np.float64(b[i])
+            if not (np.isnan(value_a) or np.isnan(value_b)):
+                if count == 0:
+                    origin_a = value_a
+                    origin_b = value_b
+                    origin_index = i
+                    total_a = 0.0
+                    total_b = 0.0
+                    total_ab = 0.0
+                    total_abs_ab = 0.0
+                    total_sq_a = 0.0
+                    total_sq_b = 0.0
+                    updates = 0
+                centered_a = value_a - origin_a
+                centered_b = value_b - origin_b
+                product = centered_a * centered_b
+                total_a += centered_a
+                total_b += centered_b
+                total_ab += product
+                if correlation:
+                    total_sq_a += centered_a * centered_a
+                    total_sq_b += centered_b * centered_b
+                else:
+                    total_abs_ab += abs(product)
+                count += 1
+                updates += 1
+
+        needs_rescan = i == start or origin_expired or dominant_exited
+        numerator_a = 0.0
+        numerator_b = 0.0
+        if count >= min_count:
+            correction_ab = total_a * total_b / count
+            numerator_ab = total_ab - correction_ab
+            roundoff_fraction = updates * FLOAT64_EPSILON
+            needs_rescan = needs_rescan or not np.isfinite(numerator_ab)
+            if correlation:
+                correction_a = total_a * total_a / count
+                correction_b = total_b * total_b / count
+                numerator_a = total_sq_a - correction_a
+                numerator_b = total_sq_b - correction_b
+                covariance_scale = np.sqrt(
+                    max(numerator_a, 0.0) * max(numerator_b, 0.0)
+                )
+                needs_rescan = needs_rescan or (
+                    not np.isfinite(numerator_a)
+                    or not np.isfinite(numerator_b)
+                    or numerator_a < 0.0
+                    or numerator_b < 0.0
+                    or roundoff_fraction * (abs(total_sq_a) + abs(correction_a))
+                    > abs(numerator_a)
+                    or roundoff_fraction * (abs(total_sq_b) + abs(correction_b))
+                    > abs(numerator_b)
+                    or roundoff_fraction * (abs(total_ab) + abs(correction_ab))
+                    > covariance_scale
+                )
+            else:
+                needs_rescan = needs_rescan or (
+                    roundoff_fraction * (abs(total_ab) + abs(correction_ab))
+                    > abs(numerator_ab)
+                )
+
+        if needs_rescan:
+            window_start = max(0, i - window + 1)
+            for j in range(i, window_start - 1, -1):
+                value_a = np.float64(a[j])
+                value_b = np.float64(b[j])
+                if not (np.isnan(value_a) or np.isnan(value_b)):
+                    origin_a = value_a
+                    origin_b = value_b
+                    origin_index = j
+                    break
+            total_a = 0.0
+            total_b = 0.0
+            total_ab = 0.0
+            total_abs_ab = 0.0
+            total_sq_a = 0.0
+            total_sq_b = 0.0
+            count = 0
+            updates = 0
+            for j in range(window_start, i + 1):
+                value_a = np.float64(a[j])
+                value_b = np.float64(b[j])
+                if not (np.isnan(value_a) or np.isnan(value_b)):
+                    centered_a = value_a - origin_a
+                    centered_b = value_b - origin_b
+                    product = centered_a * centered_b
+                    total_a += centered_a
+                    total_b += centered_b
+                    total_ab += product
+                    if correlation:
+                        total_sq_a += centered_a * centered_a
+                        total_sq_b += centered_b * centered_b
+                    else:
+                        total_abs_ab += abs(product)
+                    count += 1
+                    updates += 1
+
+            if count >= min_count:
+                correction_ab = total_a * total_b / count
+                numerator_ab = total_ab - correction_ab
+                if correlation:
+                    numerator_a = total_sq_a - total_a * total_a / count
+                    numerator_b = total_sq_b - total_b * total_b / count
+
+        if count >= min_count:
+            if correlation:
+                denominator_sq = max(numerator_a, 0.0) * max(numerator_b, 0.0)
+                if denominator_sq > 0.0:
+                    value = numerator_ab / np.sqrt(denominator_sq)
+                    out[i] = min(max(value, -1.0), 1.0)
+                else:
+                    out[i] = np.nan
+            else:
+                out[i] = numerator_ab / (count - 1)
+        else:
+            out[i] = np.nan
+
+
+@njit(cache=_ENABLE_CACHE, inline="always")
+def _move_covariance_float32(a, b, window, min_count, out, correlation):
+    """Promoted raw pairwise moments with event-local recovery checks."""
+    total_a = 0.0
+    total_b = 0.0
+    total_ab = 0.0
+    total_sq_a = 0.0
+    total_sq_b = 0.0
+    count = 0
+    inspected = False
+    trigger_index = -1
+    danger_index_a = -1
+    danger_index_b = -1
+    lower_guard_a = 0.0
+    upper_guard_a = 0.0
+    lower_guard_b = 0.0
+    upper_guard_b = 0.0
+    min_count = max(min_count, 1 if correlation else 2)
+
+    for i in range(len(a)):
+        if i >= window:
+            old_a = np.float64(a[i - window])
+            old_b = np.float64(b[i - window])
+            if not (np.isnan(old_a) or np.isnan(old_b)):
+                total_a -= old_a
+                total_b -= old_b
+                total_ab -= old_a * old_b
+                if correlation:
+                    total_sq_a -= old_a * old_a
+                    total_sq_b -= old_b * old_b
+                count -= 1
+            if danger_index_a == i - window or danger_index_b == i - window:
+                trigger_index = i
+                break
+
+        value_a = np.float64(a[i])
+        value_b = np.float64(b[i])
+        if not (np.isnan(value_a) or np.isnan(value_b)):
+            if inspected and (
+                value_a < lower_guard_a
+                or value_a > upper_guard_a
+                or value_b < lower_guard_b
+                or value_b > upper_guard_b
+            ):
+                trigger_index = i
+                break
+            total_a += value_a
+            total_b += value_b
+            total_ab += value_a * value_b
+            if correlation:
+                total_sq_a += value_a * value_a
+                total_sq_b += value_b * value_b
+            count += 1
+
+        if count >= min_count:
+            numerator_ab = total_ab - total_a * total_b / count
+            numerator_a = 0.0
+            numerator_b = 0.0
+            if correlation:
+                numerator_a = total_sq_a - total_a * total_a / count
+                numerator_b = total_sq_b - total_b * total_b / count
+            if not inspected:
+                (
+                    minimum_a,
+                    maximum_a,
+                    minimum_b,
+                    maximum_b,
+                    largest_a,
+                    runner_up_a,
+                    largest_index_a,
+                    largest_b,
+                    runner_up_b,
+                    largest_index_b,
+                    _,
+                    _,
+                ) = _inspect_pairwise_window(a, b, i, window)
+                range_a = maximum_a - minimum_a
+                range_b = maximum_b - minimum_b
+                if largest_a * FLOAT32_EPSILON_QUARTER > runner_up_a:
+                    danger_index_a = largest_index_a
+                if largest_b * FLOAT32_EPSILON_QUARTER > runner_up_b:
+                    danger_index_b = largest_index_b
+                # sqrt(window * eps) is the accumulated resolution of adjacent
+                # differences across this window, scaled by its observed range.
+                tail_a, tail_b = _trailing_pair_boundaries(
+                    a,
+                    b,
+                    i,
+                    window,
+                    range_a * np.sqrt(window * FLOAT32_EPSILON),
+                    range_b * np.sqrt(window * FLOAT32_EPSILON),
+                )
+                if tail_a >= 0 and (danger_index_a < 0 or tail_a < danger_index_a):
+                    danger_index_a = tail_a
+                if tail_b >= 0 and (danger_index_b < 0 or tail_b < danger_index_b):
+                    danger_index_b = tail_b
+                # A value outside range / eps**(1/4) can dominate the certified
+                # scale enough that its later removal loses sqrt(eps) of state.
+                growth_a = range_a / FLOAT32_EPSILON_QUARTER
+                growth_b = range_b / FLOAT32_EPSILON_QUARTER
+                lower_guard_a = minimum_a - growth_a
+                upper_guard_a = maximum_a + growth_a
+                lower_guard_b = minimum_b - growth_b
+                upper_guard_b = maximum_b + growth_b
+                inspected = True
+            if not np.isfinite(numerator_ab) or (
+                correlation and (numerator_a < 0.0 or numerator_b < 0.0)
+            ):
+                trigger_index = i
+                break
+
+            if correlation:
+                denominator_sq = numerator_a * numerator_b
+                if denominator_sq > 0.0:
+                    value = numerator_ab / np.sqrt(denominator_sq)
+                    out[i] = min(max(value, -1.0), 1.0)
+                else:
+                    out[i] = np.nan
+            else:
+                out[i] = numerator_ab / (count - 1)
+        else:
+            out[i] = np.nan
+
+    if trigger_index >= 0:
+        _move_covariance_stable_suffix(
+            a, b, window, min_count, out, trigger_index, correlation
+        )
+
+
+@njit(cache=_ENABLE_CACHE, inline="always")
+def _move_covariance_float64(a, b, window, min_count, out, correlation):
+    """Native raw pairwise moments with a causal startup scale certificate."""
+    total_a = 0.0
+    total_b = 0.0
+    total_ab = 0.0
+    total_sq_a = 0.0
+    total_sq_b = 0.0
+    count = 0
+    inspected = False
+    trigger_index = -1
+    danger_index_a = -1
+    danger_index_b = -1
+    lower_guard_a = 0.0
+    upper_guard_a = 0.0
+    lower_guard_b = 0.0
+    upper_guard_b = 0.0
+    contraction_threshold_a = 0.0
+    contraction_threshold_b = 0.0
+    contraction_count_a = 0
+    contraction_count_b = 0
+    previous_a = 0.0
+    previous_b = 0.0
+    min_count = max(min_count, 1 if correlation else 2)
+
+    for i in range(len(a)):
+        if i >= window:
+            old_a = a[i - window]
+            old_b = b[i - window]
+            if not (np.isnan(old_a) or np.isnan(old_b)):
+                total_a -= old_a
+                total_b -= old_b
+                total_ab -= old_a * old_b
+                if correlation:
+                    total_sq_a -= old_a * old_a
+                    total_sq_b -= old_b * old_b
+                count -= 1
+            if danger_index_a == i - window or danger_index_b == i - window:
+                trigger_index = i
+                break
+
+        value_a = a[i]
+        value_b = b[i]
+        if not (np.isnan(value_a) or np.isnan(value_b)):
+            if inspected:
+                if (
+                    value_a < lower_guard_a
+                    or value_a > upper_guard_a
+                    or value_b < lower_guard_b
+                    or value_b > upper_guard_b
+                ):
+                    trigger_index = i
+                    break
+                contraction_count_a = (
+                    contraction_count_a + 1
+                    if abs(value_a - previous_a) <= contraction_threshold_a
+                    else 0
+                )
+                contraction_count_b = (
+                    contraction_count_b + 1
+                    if abs(value_b - previous_b) <= contraction_threshold_b
+                    else 0
+                )
+                if (
+                    contraction_count_a >= min_count - 1
+                    or contraction_count_b >= min_count - 1
+                ):
+                    trigger_index = i
+                    break
+                previous_a = value_a
+                previous_b = value_b
+            total_a += value_a
+            total_b += value_b
+            total_ab += value_a * value_b
+            if correlation:
+                total_sq_a += value_a * value_a
+                total_sq_b += value_b * value_b
+            count += 1
+
+        if count >= min_count:
+            correction_ab = total_a * total_b / count
+            numerator_ab = total_ab - correction_ab
+            numerator_a = 0.0
+            numerator_b = 0.0
+            if correlation:
+                numerator_a = total_sq_a - total_a * total_a / count
+                numerator_b = total_sq_b - total_b * total_b / count
+            if not inspected:
+                (
+                    minimum_a,
+                    maximum_a,
+                    minimum_b,
+                    maximum_b,
+                    largest_a,
+                    runner_up_a,
+                    largest_index_a,
+                    largest_b,
+                    runner_up_b,
+                    largest_index_b,
+                    inspected_sq_a,
+                    inspected_sq_b,
+                ) = _inspect_pairwise_window(a, b, i, window)
+                range_a = maximum_a - minimum_a
+                range_b = maximum_b - minimum_b
+                correction_a = total_a * total_a / count
+                correction_b = total_b * total_b / count
+                inspected_a = inspected_sq_a - correction_a
+                inspected_b = inspected_sq_b - correction_b
+                # For a sample in [min, max], the unnormalized second moment is
+                # between range**2 / 2 and count * range**2 / 4 (Popoviciu).
+                lower_a = 0.5 * range_a * range_a
+                lower_b = 0.5 * range_b * range_b
+                upper_a = count * range_a * range_a / 4.0
+                upper_b = count * range_b * range_b / 4.0
+                upper_ab = count * range_a * range_b / 4.0
+                # One epsilon covers each product and count epsilons cover the
+                # first accumulation. These are startup bounds, not fitted knobs.
+                roundoff_a = (
+                    (count + 1)
+                    * FLOAT64_EPSILON
+                    * (abs(inspected_sq_a) + abs(correction_a))
+                )
+                roundoff_b = (
+                    (count + 1)
+                    * FLOAT64_EPSILON
+                    * (abs(inspected_sq_b) + abs(correction_b))
+                )
+                roundoff_ab = (
+                    (count + 1) * FLOAT64_EPSILON * (abs(total_ab) + abs(correction_ab))
+                )
+                if (
+                    not np.isfinite(numerator_ab)
+                    or inspected_a < 0.0
+                    or inspected_b < 0.0
+                    or roundoff_a > upper_a
+                    or roundoff_b > upper_b
+                    or roundoff_ab > upper_ab
+                    or inspected_a < lower_a - roundoff_a
+                    or inspected_b < lower_b - roundoff_b
+                    or inspected_a > upper_a + roundoff_a
+                    or inspected_b > upper_b + roundoff_b
+                    or abs(numerator_ab) > upper_ab + roundoff_ab
+                ):
+                    trigger_index = i
+                    break
+                if largest_a * FLOAT64_EPSILON_QUARTER > runner_up_a:
+                    danger_index_a = largest_index_a
+                if largest_b * FLOAT64_EPSILON_QUARTER > runner_up_b:
+                    danger_index_b = largest_index_b
+                tail_a, tail_b = _trailing_pair_boundaries(
+                    a,
+                    b,
+                    i,
+                    window,
+                    range_a * np.sqrt(window * FLOAT64_EPSILON),
+                    range_b * np.sqrt(window * FLOAT64_EPSILON),
+                )
+                if tail_a >= 0 and (danger_index_a < 0 or tail_a < danger_index_a):
+                    danger_index_a = tail_a
+                if tail_b >= 0 and (danger_index_b < 0 or tail_b < danger_index_b):
+                    danger_index_b = tail_b
+                growth_a = range_a / FLOAT64_EPSILON_QUARTER
+                growth_b = range_b / FLOAT64_EPSILON_QUARTER
+                lower_guard_a = minimum_a - growth_a
+                upper_guard_a = maximum_a + growth_a
+                lower_guard_b = minimum_b - growth_b
+                upper_guard_b = maximum_b + growth_b
+                contraction_threshold_a = range_a * FLOAT64_SQRT_EPSILON
+                contraction_threshold_b = range_b * FLOAT64_SQRT_EPSILON
+                previous_a = value_a
+                previous_b = value_b
+                inspected = True
+            if not np.isfinite(numerator_ab) or (
+                correlation and (numerator_a < 0.0 or numerator_b < 0.0)
+            ):
+                trigger_index = i
+                break
+
+            if correlation:
+                denominator_sq = numerator_a * numerator_b
+                if denominator_sq > 0.0:
+                    value = numerator_ab / np.sqrt(denominator_sq)
+                    out[i] = min(max(value, -1.0), 1.0)
+                else:
+                    out[i] = np.nan
+            else:
+                out[i] = numerator_ab / (count - 1)
+        else:
+            out[i] = np.nan
+
+    if trigger_index >= 0:
+        _move_covariance_stable_suffix(
+            a, b, window, min_count, out, trigger_index, correlation
+        )
 
 
 @ndmove.wrap(
@@ -124,61 +914,16 @@ def move_sum(a: T, window: int, min_count: int, out: T) -> None:
     [(float32[:], int64, int64, float32[:]), (float64[:], int64, int64, float64[:])]
 )
 def move_std(a: T, window: int, min_count: int, out: T) -> None:
-    asum = 0.0
-    asum_sq = 0.0
-    count = 0
-    min_count = max(min_count, 2)
-
-    for i in range(len(a)):
-        ai = a[i]
-
-        if i >= window:
-            aold = a[i - window]
-            if not np.isnan(aold):
-                asum -= aold
-                asum_sq -= aold * aold
-                count -= 1
-
-        if not np.isnan(ai):
-            asum += ai
-            asum_sq += ai * ai
-            count += 1
-
-        if count >= min_count:
-            variance = (asum_sq - asum**2 / count) / (count - 1)
-            out[i] = np.sqrt(variance)
-        else:
-            out[i] = np.nan
+    # The shared core is force-inlined, so this wrapper adds no runtime call while
+    # keeping standard deviation and variance on exactly the same state machine.
+    _move_variance(a, window, min_count, out, True)
 
 
 @ndmove.wrap(
     [(float32[:], int64, int64, float32[:]), (float64[:], int64, int64, float64[:])]
 )
 def move_var(a: T, window: int, min_count: int, out: T) -> None:
-    asum = 0.0
-    asum_sq = 0.0
-    count = 0
-    min_count = max(min_count, 2)
-
-    for i in range(len(a)):
-        ai = a[i]
-
-        if i >= window:
-            aold = a[i - window]
-            if not np.isnan(aold):
-                asum -= aold
-                asum_sq -= aold * aold
-                count -= 1
-
-        if not np.isnan(ai):
-            asum += ai
-            asum_sq += ai * ai
-            count += 1
-
-        if count >= min_count:
-            out[i] = (asum_sq - asum**2 / count) / (count - 1)
-        else:
-            out[i] = np.nan
+    _move_variance(a, window, min_count, out, False)
 
 
 @ndmove.wrap(
@@ -188,36 +933,10 @@ def move_var(a: T, window: int, min_count: int, out: T) -> None:
     ]
 )
 def move_cov(a: T, b: T, window: int, min_count: int, out: T) -> None:
-    asum = 0.0
-    bsum = 0.0
-    prodsum = (
-        0.0  # This will store the sum of products of corresponding values in a and b
-    )
-    count = 0
-    min_count = max(min_count, 2)
-
-    for i in range(len(a)):
-        ai = a[i]
-        bi = b[i]
-
-        if i >= window:
-            aold = a[i - window]
-            bold = b[i - window]
-            if not (np.isnan(aold) or np.isnan(bold)):
-                asum -= aold
-                bsum -= bold
-                prodsum -= aold * bold
-                count -= 1
-
-        if not (np.isnan(ai) or np.isnan(bi)):
-            asum += ai
-            bsum += bi
-            prodsum += ai * bi
-            count += 1
-        if count >= min_count:
-            out[i] = (prodsum - asum * bsum / count) / (count - 1)
-        else:
-            out[i] = np.nan
+    if a.itemsize == 4:
+        _move_covariance_float32(a, b, window, min_count, out, False)
+    else:
+        _move_covariance_float64(a, b, window, min_count, out, False)
 
 
 @ndmove.wrap(
@@ -227,52 +946,10 @@ def move_cov(a: T, b: T, window: int, min_count: int, out: T) -> None:
     ]
 )
 def move_corr(a: T, b: T, window: int, min_count: int, out: T) -> None:
-    asum = 0.0
-    bsum = 0.0
-    prodsum = 0.0
-    asum_sq = 0.0
-    bsum_sq = 0.0
-    count = 0
-
-    min_count = max(min_count, 1)
-
-    for i in range(len(a)):
-        ai = a[i]
-        bi = b[i]
-
-        if i >= window:
-            aold = a[i - window]
-            bold = b[i - window]
-            if not (np.isnan(aold) or np.isnan(bold)):
-                asum -= aold
-                bsum -= bold
-                prodsum -= aold * bold
-                asum_sq -= aold * aold
-                bsum_sq -= bold * bold
-                count -= 1
-
-        if not (np.isnan(ai) or np.isnan(bi)):
-            asum += ai
-            bsum += bi
-            prodsum += ai * bi
-            asum_sq += ai * ai
-            bsum_sq += bi * bi
-            count += 1
-        if count >= min_count:
-            count_reciprocal = 1.0 / count
-            avg_a = asum * count_reciprocal
-            avg_b = bsum * count_reciprocal
-            var_a = asum_sq * count_reciprocal - avg_a**2
-            var_b = bsum_sq * count_reciprocal - avg_b**2
-            cov_ab = prodsum * count_reciprocal - avg_a * avg_b
-            var_a_var_b = var_a * var_b
-            if var_a_var_b > 0:
-                out[i] = cov_ab / np.sqrt(var_a_var_b)
-            else:
-                out[i] = np.nan
-
-        else:
-            out[i] = np.nan
+    if a.itemsize == 4:
+        _move_covariance_float32(a, b, window, min_count, out, True)
+    else:
+        _move_covariance_float64(a, b, window, min_count, out, True)
 
 
 # Re-export matrix functions for backward compatibility

--- a/numbagg/test/test_benchmark.py
+++ b/numbagg/test/test_benchmark.py
@@ -4,10 +4,14 @@ import pytest
 from .. import (
     bfill,
     ffill,
+    move_corr,
     move_corrmatrix,
+    move_cov,
     move_covmatrix,
     move_exp_nancorrmatrix,
     move_exp_nancovmatrix,
+    move_std,
+    move_var,
     nancorrmatrix,
     nancovmatrix,
 )
@@ -93,6 +97,70 @@ def test_benchmark_f_bfill(benchmark, func_callable):
         rounds=100,
         iterations=10,
     )
+
+
+@pytest.fixture(
+    params=[
+        "dense-float64",
+        "dense-float32",
+        "nan-heavy-float64",
+        "offset-float64",
+        "expired-outlier-float64",
+        "repeated-outliers-float32",
+        "level-change-float64",
+        "slow-drift-float64",
+        "near-constant-float64",
+    ],
+    scope="module",
+)
+def rolling_moment_workload(request):
+    """Inputs that separate ordinary throughput from stability-path costs."""
+    rng = np.random.default_rng(0)
+    dtype = (
+        np.float32
+        if request.param in ("dense-float32", "repeated-outliers-float32")
+        else np.float64
+    )
+    a = rng.standard_normal(100_000).astype(dtype)
+    b = (0.4 * a + rng.standard_normal(len(a))).astype(dtype)
+
+    if request.param == "nan-heavy-float64":
+        a[::2] = np.nan
+        b[1::4] = np.nan
+    elif request.param == "offset-float64":
+        a += 1e8
+        b += 1e8
+    elif request.param == "expired-outlier-float64":
+        # Removing this first value forces the shifted recovery state to reanchor.
+        a[0] = 1e12
+        b[0] = -1e12
+    elif request.param == "repeated-outliers-float32":
+        a[::2_000] = 1e6
+        b[::2_000] = -1e6
+    elif request.param == "level-change-float64":
+        a[len(a) // 2 :] += 1e8
+        b[len(b) // 2 :] += 1e8
+    elif request.param == "slow-drift-float64":
+        drift = np.linspace(0.0, 1e8, len(a))
+        a += drift
+        b += drift
+    elif request.param == "near-constant-float64":
+        a = 1e8 + np.resize(np.arange(5) * 1e-7, len(a))
+        b = 1e8 + np.resize(np.arange(5)[::-1] * 1e-7, len(b))
+
+    return request.param, a, b
+
+
+@pytest.mark.parametrize(
+    "func", [move_var, move_std, move_cov, move_corr], ids=lambda x: x.__name__
+)
+@pytest.mark.benchmark(warmup=True, warmup_iterations=1)
+def test_benchmark_rolling_moment_stability(benchmark, func, rolling_moment_workload):
+    """Track ordinary and difficult rolling-moment costs independently."""
+    workload, a, b = rolling_moment_workload
+    args = (a,) if func in (move_var, move_std) else (a, b)
+    benchmark.group = f"rolling-moments|{workload}"
+    benchmark(func, *args, window=100, min_count=20)
 
 
 # Because this clears the cache, it really slows down running the tests. So we only run

--- a/numbagg/test/test_moving.py
+++ b/numbagg/test/test_moving.py
@@ -1,4 +1,5 @@
 import warnings
+from fractions import Fraction
 from typing import Any
 
 import numpy as np
@@ -7,10 +8,14 @@ from numpy.testing import assert_allclose
 
 from numbagg import (
     MOVE_FUNCS,
+    move_corr,
     move_corrmatrix,
+    move_cov,
     move_covmatrix,
     move_mean,
+    move_std,
     move_sum,
+    move_var,
 )
 
 from .conftest import COMPARISONS
@@ -190,6 +195,352 @@ def test_numerical_issues_float32_move_sum_100(rs):
     result = move_sum(arr, window=10)
     expected = np.sum(arr[:10])
     assert result[-1] == expected, result[-1] - expected
+
+
+def _exact_rolling_moments(a, b, window, min_count):
+    """Variance, covariance, and correlation of represented values, exactly."""
+    variance = np.full(len(a), np.nan)
+    covariance = np.full(len(a), np.nan)
+    correlation = np.full(len(a), np.nan)
+    for i in range(len(a)):
+        start = max(0, i - window + 1)
+        values = [
+            Fraction(float(value)) for value in a[start : i + 1] if not np.isnan(value)
+        ]
+        pairs = [
+            (Fraction(float(value_a)), Fraction(float(value_b)))
+            for value_a, value_b in zip(a[start : i + 1], b[start : i + 1])
+            if not (np.isnan(value_a) or np.isnan(value_b))
+        ]
+        if len(values) >= max(min_count, 2):
+            mean = sum(values) / len(values)
+            variance[i] = float(
+                sum((value - mean) ** 2 for value in values) / (len(values) - 1)
+            )
+        if len(pairs) >= max(min_count, 2):
+            mean_a = sum(value_a for value_a, _ in pairs) / len(pairs)
+            mean_b = sum(value_b for _, value_b in pairs) / len(pairs)
+            denominator = len(pairs) - 1
+            var_a = sum((value_a - mean_a) ** 2 for value_a, _ in pairs) / denominator
+            var_b = sum((value_b - mean_b) ** 2 for _, value_b in pairs) / denominator
+            cov = (
+                sum(
+                    (value_a - mean_a) * (value_b - mean_b)
+                    for value_a, value_b in pairs
+                )
+                / denominator
+            )
+            covariance[i] = float(cov)
+            if var_a > 0 and var_b > 0:
+                correlation[i] = float(cov) / np.sqrt(float(var_a * var_b))
+    return variance, covariance, correlation
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_move_moments_persistent_offset(dtype):
+    rng = np.random.default_rng(0)
+    a = rng.standard_normal(80).astype(dtype)
+    b = (0.4 * a + rng.standard_normal(80)).astype(dtype)
+    offset = dtype(1e4 if dtype is np.float32 else 1e8)
+    a += offset
+    b += offset
+    window = 12
+    min_count = 5
+    expected_var, expected_cov, expected_corr = _exact_rolling_moments(
+        a, b, window, min_count
+    )
+    # These inputs have unit spread. Use the same tolerance as both a relative and
+    # absolute error scale so a covariance that happens to be near zero is not
+    # divided by itself; covariance accuracy is defined by marginal spread.
+    rtol = 2e-6 if dtype is np.float32 else 2e-12
+
+    assert_allclose(
+        move_var(a, window=window, min_count=min_count),
+        expected_var,
+        rtol=rtol,
+        atol=rtol,
+    )
+    assert_allclose(
+        move_std(a, window=window, min_count=min_count),
+        np.sqrt(expected_var),
+        rtol=rtol,
+        atol=rtol,
+    )
+    assert_allclose(
+        move_cov(a, b, window=window, min_count=min_count),
+        expected_cov,
+        rtol=rtol,
+        atol=rtol,
+    )
+    assert_allclose(
+        move_corr(a, b, window=window, min_count=min_count),
+        expected_corr,
+        rtol=rtol,
+        atol=rtol,
+    )
+
+
+@pytest.mark.parametrize("event", ["leading-outlier", "level-change"])
+def test_move_moments_recover_from_scale_change(event):
+    rng = np.random.default_rng(1)
+    a = rng.standard_normal(80)
+    b = 0.4 * a + rng.standard_normal(80)
+    window = 10
+    min_count = 4
+    if event == "leading-outlier":
+        a[0] = 1e12
+        b[0] = -1e12
+    else:
+        a[30:] += 1e8
+        b[30:] += 1e8
+
+    expected_var, expected_cov, expected_corr = _exact_rolling_moments(
+        a, b, window, min_count
+    )
+    actual = (
+        move_var(a, window=window, min_count=min_count),
+        move_std(a, window=window, min_count=min_count),
+        move_cov(a, b, window=window, min_count=min_count),
+        move_corr(a, b, window=window, min_count=min_count),
+    )
+    expected = (expected_var, np.sqrt(expected_var), expected_cov, expected_corr)
+    skip = window if event == "leading-outlier" else 0
+    for result, reference in zip(actual, expected):
+        assert_allclose(result[skip:], reference[skip:], rtol=2e-12, atol=1e-14)
+
+
+def test_move_moments_reanchor_after_repeated_float32_outliers():
+    rng = np.random.default_rng(233)
+    a = rng.standard_normal(50).astype(np.float32)
+    b = (0.4 * a + rng.standard_normal(50)).astype(np.float32)
+    a[[0, 3, 19]] = 1e6
+    b[[0, 3, 19]] = -1e6
+    window = 4
+    min_count = 3
+    expected_var, expected_cov, expected_corr = _exact_rolling_moments(
+        a, b, window, min_count
+    )
+
+    actual = (
+        move_var(a, window=window, min_count=min_count),
+        move_std(a, window=window, min_count=min_count),
+        move_cov(a, b, window=window, min_count=min_count),
+        move_corr(a, b, window=window, min_count=min_count),
+    )
+    expected = (expected_var, np.sqrt(expected_var), expected_cov, expected_corr)
+    for result, reference in zip(actual, expected):
+        assert_allclose(result, reference, rtol=2e-6, atol=2e-6)
+
+
+def test_move_moments_recover_when_outlier_expires_below_min_count():
+    close_float32 = np.array([-0.99379987, -1.0016286], dtype=np.float32)
+    close_var, _, close_corr = _exact_rolling_moments(
+        close_float32, close_float32[::-1].copy(), 2, 2
+    )
+    assert_allclose(move_var(close_float32, window=2), close_var, rtol=2e-6)
+    assert_allclose(
+        move_corr(close_float32, close_float32[::-1].copy(), window=2),
+        close_corr,
+        rtol=2e-6,
+    )
+
+    # With a two-value window, the destructive removal happens while only two
+    # values are in state. It still has to trigger recovery.
+    variance_data = np.array([1e14, 0.0, 1.0, 1.1, 0.9])
+    expected_var, _, _ = _exact_rolling_moments(variance_data, variance_data, 2, 2)
+    assert_allclose(move_var(variance_data, window=2), expected_var, rtol=2e-12)
+    assert_allclose(
+        move_std(variance_data, window=2), np.sqrt(expected_var), rtol=2e-12
+    )
+
+    # The outlier leaves while only one valid pair remains, so that output is
+    # NaN. Recovery must remain latched for the next emit-capable window.
+    a = np.array([1e14, np.nan, 0.483, np.nan, 0.023])
+    b = np.array([-1e14, np.nan, 0.980, np.nan, 0.977])
+    _, expected_cov, expected_corr = _exact_rolling_moments(a, b, 3, 2)
+    assert_allclose(move_cov(a, b, window=3, min_count=2), expected_cov, rtol=2e-12)
+    assert_allclose(move_corr(a, b, window=3, min_count=2), expected_corr, rtol=2e-12)
+
+
+def test_move_moments_slow_drift_accuracy_floor():
+    rng = np.random.default_rng(4)
+    size = 100_000
+    window = 52
+    min_count = 25
+    drift = np.linspace(0.0, 1e8, size)
+    a = rng.standard_normal(size) + drift
+    b = 0.4 * a + rng.standard_normal(size)
+    indices = np.unique(np.linspace(window - 1, size - 1, 64, dtype=np.int64))
+    actual_var = move_var(a, window=window, min_count=min_count)
+    actual_std = move_std(a, window=window, min_count=min_count)
+    actual_cov = move_cov(a, b, window=window, min_count=min_count)
+    actual_corr = move_corr(a, b, window=window, min_count=min_count)
+
+    for i in indices:
+        window_a = a[i - window + 1 : i + 1]
+        window_b = b[i - window + 1 : i + 1]
+        expected_var, expected_cov, expected_corr = _exact_rolling_moments(
+            window_a, window_b, window, min_count
+        )
+        actual = (
+            actual_var[i],
+            actual_std[i],
+            actual_cov[i],
+            actual_corr[i],
+        )
+        expected = (
+            expected_var[-1],
+            np.sqrt(expected_var[-1]),
+            expected_cov[-1],
+            expected_corr[-1],
+        )
+        assert_allclose(actual, expected, rtol=1e-6, atol=1e-8)
+
+
+def test_move_moments_do_not_look_ahead():
+    rng = np.random.default_rng(2)
+    a = rng.standard_normal(50) + 1e8
+    b = rng.standard_normal(50) + 1e8
+    window = 8
+    min_count = 3
+
+    for function, arrays_ in (
+        (move_var, (a,)),
+        (move_std, (a,)),
+        (move_cov, (a, b)),
+        (move_corr, (a, b)),
+    ):
+        callable_: Any = function
+        complete = callable_(*arrays_, window=window, min_count=min_count)
+        for length in (min_count, window, window + 1, len(a) - 1):
+            prefix = callable_(
+                *(array[:length] for array in arrays_),
+                window=min(window, length),
+                min_count=min_count,
+            )
+            np.testing.assert_array_equal(
+                prefix,
+                complete[:length],
+                err_msg=f"{function.__name__}, prefix={length}",
+            )
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_move_moment_invariants_on_degenerate_windows(dtype):
+    representable_step = 1e-2 if dtype is np.float32 else 1e-7
+    pattern = np.resize(np.array([-2.0, -1.0, 0.0, 1.0, 2.0]) * representable_step, 100)
+    a = (1e4 if dtype is np.float32 else 1e8) + pattern
+    a = a.astype(dtype)
+    constant = np.full(100, a[0], dtype=dtype)
+
+    variance = move_var(a, window=9, min_count=2)
+    correlation = move_corr(a, a[::-1].copy(), window=9, min_count=2)
+    finite_correlation = correlation[np.isfinite(correlation)]
+    assert np.all(variance[np.isfinite(variance)] >= 0.0)
+    assert np.all(np.abs(finite_correlation) <= 1.0)
+    assert_allclose(move_var(constant, window=9)[8:], 0.0)
+    assert_allclose(move_std(constant, window=9)[8:], 0.0)
+    assert_allclose(move_cov(constant, constant, window=9)[8:], 0.0)
+    assert np.all(np.isnan(move_corr(constant, constant, window=9)[8:]))
+
+
+def test_move_covariance_pairwise_nan_reference():
+    a = np.array([1e8, np.nan, 1e8 + 1, 1e8 + 2, np.nan, 1e8 + 3])
+    b = np.array([1e8 + 3, 1e8 + 2, np.nan, 1e8 + 1, 1e8, 1e8 - 1])
+    expected_var, expected_cov, expected_corr = _exact_rolling_moments(a, b, 5, 2)
+
+    assert_allclose(move_var(a, window=5, min_count=2), expected_var, rtol=2e-12)
+    assert_allclose(move_cov(a, b, window=5, min_count=2), expected_cov, rtol=2e-12)
+    assert_allclose(move_corr(a, b, window=5, min_count=2), expected_corr, rtol=2e-12)
+
+
+def test_move_pairwise_moments_recover_from_constant_prefix():
+    """The first emitted window can already contain an old and a new regime."""
+    rng = np.random.default_rng(3501)
+    a = rng.standard_normal(69)
+    b = 0.4 * a + rng.standard_normal(69)
+    a[:23] = 1e8
+    b[:23] = -1e8
+    window = 36
+    min_count = 32
+    _, expected_cov, expected_corr = _exact_rolling_moments(a, b, window, min_count)
+
+    assert_allclose(
+        move_cov(a, b, window=window, min_count=min_count),
+        expected_cov,
+        rtol=2e-12,
+        atol=2e-12,
+    )
+    assert_allclose(
+        move_corr(a, b, window=window, min_count=min_count),
+        expected_corr,
+        rtol=2e-12,
+        atol=2e-12,
+    )
+
+
+def test_move_variance_recovers_after_late_scale_expansion_and_contraction():
+    """A small initial min_count must not freeze an unrepresentative scale."""
+    rng = np.random.default_rng(3701)
+    a = np.empty(119, dtype=np.float32)
+    a[:59] = (rng.standard_normal(59) * 1e4).astype(np.float32)
+    a[59:] = (1e4 + rng.standard_normal(60)).astype(np.float32)
+    window = 15
+    min_count = 3
+    expected_var, _, _ = _exact_rolling_moments(a, a, window, min_count)
+
+    assert_allclose(
+        move_var(a, window=window, min_count=min_count),
+        expected_var,
+        rtol=2e-5,
+        atol=2e-5,
+    )
+
+
+@pytest.mark.parametrize("seed", [2901, 2902, 2903])
+def test_move_pairwise_moments_same_magnitude_contraction(seed):
+    """A spread can collapse without observations growing in magnitude."""
+    rng = np.random.default_rng(seed)
+    a = rng.standard_normal(100) * 1e4
+    b = 0.4 * a + rng.standard_normal(100) * 1e4
+    a[50:] = 1e4 + rng.standard_normal(50)
+    b[50:] = -1e4 + rng.standard_normal(50)
+    window = 20
+    min_count = 8
+    expected_var_a, expected_cov, expected_corr = _exact_rolling_moments(
+        a, b, window, min_count
+    )
+    expected_var_b, _, _ = _exact_rolling_moments(b, a, window, min_count)
+
+    actual_cov = move_cov(a, b, window=window, min_count=min_count)
+    pair_scale = np.sqrt(expected_var_a * expected_var_b)
+    finite = np.isfinite(expected_cov)
+    assert np.all(
+        np.abs(actual_cov[finite] - expected_cov[finite]) < 3e-7 * pair_scale[finite]
+    )
+    assert_allclose(
+        move_corr(a, b, window=window, min_count=min_count),
+        expected_corr,
+        rtol=3e-7,
+        atol=3e-7,
+    )
+
+
+def test_move_pairwise_near_constant_float32_accuracy_floor():
+    """Pin the selected pandas-compatible speed/accuracy tradeoff."""
+    a = np.array([9999.9970703125, 9999.998046875, 9999.998046875], np.float32)
+    b = np.array([10000.0029296875, 9999.9990234375, 10000.001953125], np.float32)
+    _, expected_cov, expected_corr = _exact_rolling_moments(a, b, 3, 3)
+
+    # Promoted raw products match pandas covariance on this worst generated case.
+    # NumPy's two-pass result is more accurate; keep the discrepancy below 1% of
+    # marginal spread and 0.003 absolute correlation rather than pretending the
+    # fast path is exact.
+    actual_cov = move_cov(a, b, window=3)
+    actual_corr = move_corr(a, b, window=3)
+    pair_scale = abs(expected_cov[-1] / expected_corr[-1])
+    assert abs(actual_cov[-1] - expected_cov[-1]) < 0.01 * pair_scale
+    assert abs(actual_corr[-1] - expected_corr[-1]) < 0.003
 
 
 def slow_move_mean(a, window, min_count=None, axis=-1):


### PR DESCRIPTION
## Summary

Stabilize the scalar rolling variance, standard deviation, covariance, and correlation kernels without imposing a second pass on ordinary inputs.

The previous raw-moment recurrences can catastrophically cancel when values have a large level relative to their spread. Worse, an outlier or level change can poison the rolling state after that observation has left the window. These failures produce obviously wrong variances, covariances, and correlations on inputs other libraries handle.

## Approach

- Retain a compact raw fast path for ordinary workloads.
- Detect unsafe cancellation causally and switch only the affected output suffix to a shifted float64 recurrence.
- Continuously guard variance and standard deviation; use dtype-specific startup and scale-event checks for covariance and correlation.
- Promote float32 products before accumulation while preserving the public output dtype.
- Keep recovery state constant-size, with no scratch allocation proportional to input length.
- Document numerical and performance principles for future algorithm choices.

## Evidence

Accuracy probes covered 5,000 randomized histories plus million-element persistent-offset, contraction, outlier, and ordinary histories. They found no finite-mask, causality, or stated error-bound failures. Against exact or shifted references, representative worst errors were about `1.4e-5` for float32 rolling variance, `7.1e-6` for standard deviation, `8.7e-3` of marginal covariance scale for an intentionally documented three-observation near-constant float32 case, and `2.9e-3` absolute correlation for that same case. The prior implementation is catastrophic on that case; the covariance result agrees with pandas to the tested precision and the correlation is closer than pandas.

On the ordinary warm benchmark grid, median runtime was `1.067x` baseline and the geometric mean was `1.140x`, with individual cases from `0.912x` to `1.857x`. Per-function medians were `1.065x` for variance, `1.061x` for standard deviation, `1.065x` for covariance, and `1.166x` for correlation. Inputs that trigger stable recovery had a median cost of `2.062x`, as intended: pathological cancellation may pay for a second pass so ordinary inputs do not. Peak output-plus-kernel scratch changed by only about 2–3 KB in million-element probes.

The benchmark suite now contains ordinary, persistent-offset, contraction, outlier, and pairwise-NaN rolling stability workloads so the fast and protected paths remain visible separately.

## Verification

- `uv run pre-commit run --all-files`
- `uv run pytest` (`1232 passed, 1049 skipped, 1 xfailed`)
- focused rolling tests (`99 passed, 8 skipped`)

> _This was written by Codex on behalf of @max-sixty_
